### PR TITLE
feat: add clipboard fallback when cursor not in text field

### DIFF
--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -194,7 +194,7 @@ class Config:
     # Paste threshold: texts with more words than this will use clipboard paste
     # instead of character-by-character streaming (faster for long dictations)
     # Set to 0 to always use streaming, or -1 to always use paste
-    PASTE_THRESHOLD_WORDS = int(os.getenv("PASTE_THRESHOLD_WORDS", "200"))
+    PASTE_THRESHOLD_WORDS = int(os.getenv("PASTE_THRESHOLD_WORDS", "100"))
 
     DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 


### PR DESCRIPTION
## Summary
- When cursor is not in a text input field, transcribed text is automatically copied to clipboard instead of being typed
- User can then paste with Ctrl+V anywhere on the system
- Detection uses AT-SPI widget focus + window class detection for non-text apps (file managers, desktop shells, media viewers)
- Reduces `PASTE_THRESHOLD_WORDS` default from 200 → 100 words for faster output

## How It Works

| Context | Detection Method | Output |
|---------|-----------------|--------|
| Terminal | Window class | Types directly |
| Code editor | Window class | Types directly |
| Text field | AT-SPI widget role | Types directly |
| File manager | Known non-text app | **Clipboard** |
| Desktop/shell | Known non-text app | **Clipboard** |
| Image/video viewer | Known non-text app | **Clipboard** |

## Test plan
- [ ] Dictate while focused on a terminal → text should be typed
- [ ] Dictate while focused on VS Code → text should be typed
- [ ] Dictate while focused on desktop (no window) → text should be copied to clipboard
- [ ] Dictate while focused on Nautilus file manager → text should be copied to clipboard
- [ ] Verify notification shows "📋 Copied to Clipboard" when clipboard is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)