### PR TITLE
feat: keyboard hot-plug detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ gtk = [
 ]
 fnkey = [
     "evdev>=1.6.0",
+    "pyudev>=0.24.0",
 ]
 llm = [
     "google-genai>=1.0.0",

--- a/src/dicton/fn_key_handler.py
+++ b/src/dicton/fn_key_handler.py
@@ -34,42 +34,134 @@ KEY_RIGHTALT = 100
 
 # Secondary hotkey keycode mapping (name -> evdev keycode)
 SECONDARY_HOTKEY_MAP = {
-    "escape": 1, "esc": 1,
-    "f1": 59, "f2": 60, "f3": 61, "f4": 62, "f5": 63, "f6": 64,
-    "f7": 65, "f8": 66, "f9": 67, "f10": 68, "f11": 87, "f12": 88,
-    "capslock": 58, "caps": 58,
-    "pause": 119, "break": 119,
-    "insert": 110, "ins": 110,
-    "home": 102, "end": 107,
-    "pageup": 104, "pgup": 104,
-    "pagedown": 109, "pgdn": 109,
+    "escape": 1,
+    "esc": 1,
+    "f1": 59,
+    "f2": 60,
+    "f3": 61,
+    "f4": 62,
+    "f5": 63,
+    "f6": 64,
+    "f7": 65,
+    "f8": 66,
+    "f9": 67,
+    "f10": 68,
+    "f11": 87,
+    "f12": 88,
+    "capslock": 58,
+    "caps": 58,
+    "pause": 119,
+    "break": 119,
+    "insert": 110,
+    "ins": 110,
+    "home": 102,
+    "end": 107,
+    "pageup": 104,
+    "pgup": 104,
+    "pagedown": 109,
+    "pgdn": 109,
 }
 
 # Full key name to evdev keycode mapping (for custom hotkey parsing)
 KEY_NAME_MAP = {
     # Letters
-    "a": 30, "b": 48, "c": 46, "d": 32, "e": 18, "f": 33, "g": 34, "h": 35,
-    "i": 23, "j": 36, "k": 37, "l": 38, "m": 50, "n": 49, "o": 24, "p": 25,
-    "q": 16, "r": 19, "s": 31, "t": 20, "u": 22, "v": 47, "w": 17, "x": 45,
-    "y": 21, "z": 44,
+    "a": 30,
+    "b": 48,
+    "c": 46,
+    "d": 32,
+    "e": 18,
+    "f": 33,
+    "g": 34,
+    "h": 35,
+    "i": 23,
+    "j": 36,
+    "k": 37,
+    "l": 38,
+    "m": 50,
+    "n": 49,
+    "o": 24,
+    "p": 25,
+    "q": 16,
+    "r": 19,
+    "s": 31,
+    "t": 20,
+    "u": 22,
+    "v": 47,
+    "w": 17,
+    "x": 45,
+    "y": 21,
+    "z": 44,
     # Numbers
-    "0": 11, "1": 2, "2": 3, "3": 4, "4": 5, "5": 6, "6": 7, "7": 8, "8": 9, "9": 10,
+    "0": 11,
+    "1": 2,
+    "2": 3,
+    "3": 4,
+    "4": 5,
+    "5": 6,
+    "6": 7,
+    "7": 8,
+    "8": 9,
+    "9": 10,
     # Special keys (include secondary hotkeys for completeness)
-    "escape": 1, "esc": 1,
-    "f1": 59, "f2": 60, "f3": 61, "f4": 62, "f5": 63, "f6": 64,
-    "f7": 65, "f8": 66, "f9": 67, "f10": 68, "f11": 87, "f12": 88,
-    "capslock": 58, "caps": 58,
-    "tab": 15, "space": 57, "enter": 28, "return": 28,
-    "backspace": 14, "delete": 111, "del": 111,
-    "insert": 110, "ins": 110,
-    "home": 102, "end": 107,
-    "pageup": 104, "pgup": 104, "pagedown": 109, "pgdn": 109,
-    "up": 103, "down": 108, "left": 105, "right": 106,
-    "pause": 119, "break": 119,
-    "grave": 41, "`": 41, "minus": 12, "-": 12, "equal": 13, "=": 13,
-    "bracketleft": 26, "[": 26, "bracketright": 27, "]": 27,
-    "backslash": 43, "\\": 43, "semicolon": 39, ";": 39, "apostrophe": 40, "'": 40,
-    "comma": 51, ",": 51, "period": 52, ".": 52, "slash": 53, "/": 53,
+    "escape": 1,
+    "esc": 1,
+    "f1": 59,
+    "f2": 60,
+    "f3": 61,
+    "f4": 62,
+    "f5": 63,
+    "f6": 64,
+    "f7": 65,
+    "f8": 66,
+    "f9": 67,
+    "f10": 68,
+    "f11": 87,
+    "f12": 88,
+    "capslock": 58,
+    "caps": 58,
+    "tab": 15,
+    "space": 57,
+    "enter": 28,
+    "return": 28,
+    "backspace": 14,
+    "delete": 111,
+    "del": 111,
+    "insert": 110,
+    "ins": 110,
+    "home": 102,
+    "end": 107,
+    "pageup": 104,
+    "pgup": 104,
+    "pagedown": 109,
+    "pgdn": 109,
+    "up": 103,
+    "down": 108,
+    "left": 105,
+    "right": 106,
+    "pause": 119,
+    "break": 119,
+    "grave": 41,
+    "`": 41,
+    "minus": 12,
+    "-": 12,
+    "equal": 13,
+    "=": 13,
+    "bracketleft": 26,
+    "[": 26,
+    "bracketright": 27,
+    "]": 27,
+    "backslash": 43,
+    "\\": 43,
+    "semicolon": 39,
+    ";": 39,
+    "apostrophe": 40,
+    "'": 40,
+    "comma": 51,
+    ",": 51,
+    "period": 52,
+    ".": 52,
+    "slash": 53,
+    "/": 53,
 }
 
 
@@ -156,7 +248,9 @@ class FnKeyHandler:
         self._wake_pipe_w: int | None = None  # Write end of self-pipe
         self._device_monitor_thread: threading.Thread | None = None
         self._pyudev_available = False
-        self._pending_refresh = False  # Flag to signal device refresh needed
+        self._pending_refresh = threading.Event()  # Thread-safe flag for device refresh
+        self._last_refresh_time: float = 0  # For debouncing rapid events
+        self._refresh_debounce_ms = 500  # Debounce window in milliseconds
 
         # Secondary hotkeys: mapping of keycode → ProcessingMode
         # Each secondary hotkey triggers a specific mode directly (ignores modifier keys)
@@ -181,7 +275,9 @@ class FnKeyHandler:
 
         # Debug: show what config values we're reading
         if config.DEBUG:
-            print(f"Secondary hotkey config: basic={config.SECONDARY_HOTKEY}, translation={config.SECONDARY_HOTKEY_TRANSLATION}, act={config.SECONDARY_HOTKEY_ACT_ON_TEXT}")
+            print(
+                f"Secondary hotkey config: basic={config.SECONDARY_HOTKEY}, translation={config.SECONDARY_HOTKEY_TRANSLATION}, act={config.SECONDARY_HOTKEY_ACT_ON_TEXT}"
+            )
 
         # Basic mode (F1 by default)
         keycode = SECONDARY_HOTKEY_MAP.get(config.SECONDARY_HOTKEY)
@@ -255,7 +351,9 @@ class FnKeyHandler:
         self._custom_hotkey_requires_alt = requires_alt
 
         if config.DEBUG:
-            print(f"Custom hotkey parsed: key={main_key}({keycode}), ctrl={requires_ctrl}, shift={requires_shift}, alt={requires_alt}")
+            print(
+                f"Custom hotkey parsed: key={main_key}({keycode}), ctrl={requires_ctrl}, shift={requires_shift}, alt={requires_alt}"
+            )
 
     def _is_custom_hotkey_modifiers_pressed(self) -> bool:
         """Check if the required modifiers for custom hotkey are currently pressed."""
@@ -329,11 +427,15 @@ class FnKeyHandler:
         if self._secondary_hotkeys:
             for keycode, mode in self._secondary_hotkeys.items():
                 # Find the key name from the keycode
-                key_name = next((k for k, v in SECONDARY_HOTKEY_MAP.items() if v == keycode), str(keycode))
+                key_name = next(
+                    (k for k, v in SECONDARY_HOTKEY_MAP.items() if v == keycode), str(keycode)
+                )
                 print(f"Secondary hotkey: '{key_name}' → {mode.name}")
             if self._secondary_devices:
                 device_names = [d.name for d in self._secondary_devices]
-                print(f"Secondary hotkeys listening on {len(device_names)} device(s): {', '.join(device_names)}")
+                print(
+                    f"Secondary hotkeys listening on {len(device_names)} device(s): {', '.join(device_names)}"
+                )
 
         return True
 
@@ -396,6 +498,8 @@ class FnKeyHandler:
 
         This runs in a separate thread and signals the listener loop
         when devices change so it can refresh the device list.
+
+        Uses poll with timeout to allow clean shutdown.
         """
         try:
             import pyudev
@@ -407,9 +511,12 @@ class FnKeyHandler:
             if config.DEBUG:
                 print("Device monitor started (pyudev)")
 
-            for device in iter(monitor.poll, None):
-                if not self._running:
-                    break
+            # Use timeout-based polling instead of blocking iter()
+            while self._running:
+                device = monitor.poll(timeout=1.0)
+                if device is None:
+                    # Timeout - check _running and continue
+                    continue
 
                 # Only interested in event devices (keyboards)
                 if device.device_node and device.device_node.startswith("/dev/input/event"):
@@ -419,12 +526,9 @@ class FnKeyHandler:
                             print(f"Device {action}: {device.device_node}")
 
                         # Signal the listener loop to refresh devices
-                        self._pending_refresh = True
+                        # Debouncing is handled in the listener loop
+                        self._pending_refresh.set()
                         self._wake_select()
-
-                        # Small delay to let udev finish setting up the device
-                        if action == "add":
-                            time.sleep(0.5)
 
         except Exception as e:
             if self._running and config.DEBUG:
@@ -433,14 +537,19 @@ class FnKeyHandler:
     def _refresh_devices(self):
         """Refresh the device list after a hot-plug event.
 
-        Called from the listener loop when _pending_refresh is True.
-        Closes old devices and opens new ones.
+        Called from the listener loop when _pending_refresh is set.
+        Finds new devices OUTSIDE the lock (slow I/O), then updates
+        the device list INSIDE the lock (fast).
         """
         if config.DEBUG:
             print("Refreshing keyboard devices...")
 
+        # Find new devices OUTSIDE the lock (slow I/O operation)
+        new_primary, new_secondary = self._find_keyboard_devices()
+
+        # Update devices INSIDE the lock (fast operation)
         with self._devices_lock:
-            # Close existing devices
+            # Close old devices
             if self._device:
                 try:
                     self._device.close()
@@ -452,8 +561,9 @@ class FnKeyHandler:
                 except Exception:
                     pass
 
-            # Find new devices
-            self._device, self._secondary_devices = self._find_keyboard_devices()
+            # Assign new devices
+            self._device = new_primary
+            self._secondary_devices = new_secondary
 
             if config.DEBUG:
                 if self._device:
@@ -461,8 +571,6 @@ class FnKeyHandler:
                 if self._secondary_devices:
                     names = [d.name for d in self._secondary_devices]
                     print(f"Secondary devices: {', '.join(names)}")
-
-        self._pending_refresh = False
 
     def _find_keyboard_devices(self):
         """Find keyboard devices for FN key, custom hotkey, and secondary hotkey.
@@ -493,7 +601,9 @@ class FnKeyHandler:
                         has_wakeup = KEY_WAKEUP in keys
                         is_ext = is_external_keyboard(device.name)
                         if has_wakeup or is_ext:
-                            print(f"  {device.path}: {device.name} (WAKEUP={has_wakeup}, external={is_ext})")
+                            print(
+                                f"  {device.path}: {device.name} (WAKEUP={has_wakeup}, external={is_ext})"
+                            )
 
             primary_device = None
             secondary_devices = []
@@ -594,11 +704,15 @@ class FnKeyHandler:
                         print(f"Listening for secondary hotkey on: {sec_device.name}")
 
             while self._running:
-                # Check if we need to refresh devices (hot-plug event)
-                if self._pending_refresh:
-                    self._refresh_devices()
-                    with self._devices_lock:
-                        devices = self._build_device_fd_map()
+                # Check if we need to refresh devices (hot-plug event) with debouncing
+                if self._pending_refresh.is_set():
+                    elapsed_ms = (time.time() - self._last_refresh_time) * 1000
+                    if elapsed_ms >= self._refresh_debounce_ms:
+                        self._refresh_devices()
+                        self._pending_refresh.clear()
+                        self._last_refresh_time = time.time()
+                        with self._devices_lock:
+                            devices = self._build_device_fd_map()
 
                 # Build fd list for select, including wake pipe
                 fds = list(devices.keys())
@@ -615,7 +729,7 @@ class FnKeyHandler:
                     r, _, _ = select.select(fds, [], [], 0.1)
                 except (ValueError, OSError):
                     # Invalid fd in list (device unplugged) - refresh
-                    self._pending_refresh = True
+                    self._pending_refresh.set()
                     continue
 
                 for fd in r:
@@ -639,7 +753,7 @@ class FnKeyHandler:
                         # Device unplugged - trigger refresh
                         if config.DEBUG:
                             print(f"Device read error (unplugged?): {device.name}")
-                        self._pending_refresh = True
+                        self._pending_refresh.set()
                         continue
 
                     for event in events:
@@ -652,7 +766,9 @@ class FnKeyHandler:
 
                         # Debug: log key events
                         if config.DEBUG:
-                            print(f"Key event from {device.name}: code={event.code} value={event.value}")
+                            print(
+                                f"Key event from {device.name}: code={event.code} value={event.value}"
+                            )
 
                         # Track modifier key states
                         self._update_modifier_state(event.code, event.value)
@@ -691,8 +807,12 @@ class FnKeyHandler:
                             elif event.value == 0:  # Key up
                                 # Only process key up if we're in a recording state
                                 # (to avoid processing releases for key presses that weren't triggered)
-                                if self._state in (HotkeyState.RECORDING_PTT, HotkeyState.RECORDING_TOGGLE,
-                                                   HotkeyState.WAITING_ACTIVATION, HotkeyState.WAITING_DOUBLE):
+                                if self._state in (
+                                    HotkeyState.RECORDING_PTT,
+                                    HotkeyState.RECORDING_TOGGLE,
+                                    HotkeyState.WAITING_ACTIVATION,
+                                    HotkeyState.WAITING_DOUBLE,
+                                ):
                                     self._on_fn_key_up()
                         elif secondary_mode is not None:
                             # Secondary hotkey: use the specific mode for this key
@@ -893,9 +1013,7 @@ class FnKeyHandler:
         if self.on_start_recording:
             mode = self._current_mode
             # Run callback in separate thread to not block event handling
-            threading.Thread(
-                target=lambda: self.on_start_recording(mode), daemon=True
-            ).start()
+            threading.Thread(target=lambda: self.on_start_recording(mode), daemon=True).start()
 
     def _trigger_stop_recording(self):
         """Trigger recording stop callback (will process audio)"""

--- a/tests/test_fn_key_hotplug.py
+++ b/tests/test_fn_key_hotplug.py
@@ -1,0 +1,264 @@
+"""Tests for FN key handler hot-plug detection.
+
+Tests cover:
+- threading.Event synchronization
+- Device refresh with mock devices
+- Poll timeout shutdown behavior
+- Debouncing rapid events
+- Graceful degradation without pyudev
+"""
+
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def create_mock_evdev():
+    """Create a mock evdev module for testing."""
+    mock_evdev = MagicMock()
+    mock_evdev.InputDevice = MagicMock()
+    mock_evdev.list_devices = MagicMock(return_value=[])
+    mock_evdev.ecodes = MagicMock()
+    mock_evdev.ecodes.EV_KEY = 1
+    mock_evdev.ecodes.KEY_A = 30
+    mock_evdev.ecodes.KEY_Z = 44
+    return mock_evdev
+
+
+@pytest.fixture
+def mock_evdev_module():
+    """Fixture to mock evdev module."""
+    mock_evdev = create_mock_evdev()
+    with patch.dict(sys.modules, {"evdev": mock_evdev, "evdev.ecodes": mock_evdev.ecodes}):
+        yield mock_evdev
+
+
+@pytest.fixture
+def fn_handler(mock_evdev_module):
+    """Fixture to create FnKeyHandler with mocked dependencies."""
+    # Also mock pyudev as optional
+    with patch.dict(sys.modules, {"pyudev": MagicMock()}):
+        # Clear any cached imports
+        if "dicton.fn_key_handler" in sys.modules:
+            del sys.modules["dicton.fn_key_handler"]
+
+        from dicton.fn_key_handler import FnKeyHandler
+
+        handler = FnKeyHandler()
+        yield handler
+
+
+class TestPendingRefreshEvent:
+    """Test threading.Event synchronization for _pending_refresh."""
+
+    def test_event_initial_state(self, fn_handler):
+        """Event should start in unset state."""
+        assert not fn_handler._pending_refresh.is_set()
+
+    def test_event_set_and_clear(self, fn_handler):
+        """Event should be settable and clearable."""
+        fn_handler._pending_refresh.set()
+        assert fn_handler._pending_refresh.is_set()
+
+        fn_handler._pending_refresh.clear()
+        assert not fn_handler._pending_refresh.is_set()
+
+    def test_event_thread_safety(self, fn_handler):
+        """Event should be safely accessible from multiple threads."""
+        results = []
+
+        def setter():
+            for _ in range(100):
+                fn_handler._pending_refresh.set()
+                time.sleep(0.001)
+
+        def checker():
+            for _ in range(100):
+                results.append(fn_handler._pending_refresh.is_set())
+                time.sleep(0.001)
+
+        t1 = threading.Thread(target=setter)
+        t2 = threading.Thread(target=checker)
+
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # Should have completed without exceptions
+        assert len(results) == 100
+
+
+class TestRefreshDevicesLocking:
+    """Test that _refresh_devices performs I/O outside the lock."""
+
+    def test_find_devices_called_outside_lock(self, fn_handler):
+        """_find_keyboard_devices should be called outside _devices_lock."""
+        # Track when find_devices is called relative to lock
+        call_order = []
+
+        def mock_find():
+            # Check if lock is held
+            acquired = fn_handler._devices_lock.acquire(blocking=False)
+            if acquired:
+                call_order.append("find_outside_lock")
+                fn_handler._devices_lock.release()
+            else:
+                call_order.append("find_inside_lock")
+            return None, []
+
+        with patch.object(fn_handler, "_find_keyboard_devices", mock_find):
+            fn_handler._refresh_devices()
+
+        # _find_keyboard_devices should be called outside the lock
+        assert "find_outside_lock" in call_order
+
+
+class TestDebouncing:
+    """Test debouncing of rapid hot-plug events."""
+
+    def test_debounce_timing_initialization(self, fn_handler):
+        """Debounce fields should be initialized."""
+        assert fn_handler._last_refresh_time == 0
+        assert fn_handler._refresh_debounce_ms == 500
+
+    def test_rapid_events_debounced(self, fn_handler):
+        """Rapid events within debounce window should not trigger multiple refreshes."""
+        refresh_count = [0]
+
+        def counting_refresh():
+            refresh_count[0] += 1
+
+        # Simulate the debounce logic from _listen_loop
+        def simulate_debounced_refresh():
+            if fn_handler._pending_refresh.is_set():
+                elapsed_ms = (time.time() - fn_handler._last_refresh_time) * 1000
+                if elapsed_ms >= fn_handler._refresh_debounce_ms:
+                    counting_refresh()
+                    fn_handler._pending_refresh.clear()
+                    fn_handler._last_refresh_time = time.time()
+
+        # First refresh should go through
+        fn_handler._pending_refresh.set()
+        simulate_debounced_refresh()
+        assert refresh_count[0] == 1
+
+        # Immediate second event should be debounced
+        fn_handler._pending_refresh.set()
+        simulate_debounced_refresh()
+        assert refresh_count[0] == 1  # Still 1, debounced
+
+        # After debounce window, should go through
+        fn_handler._last_refresh_time = time.time() - 1  # Simulate 1s ago
+        fn_handler._pending_refresh.set()
+        simulate_debounced_refresh()
+        assert refresh_count[0] == 2
+
+
+class TestGracefulDegradation:
+    """Test behavior when pyudev is not available."""
+
+    def test_works_without_pyudev(self, mock_evdev_module):
+        """Handler should work without pyudev (no hot-plug detection)."""
+        # Import without pyudev in sys.modules
+        with patch.dict(sys.modules, {"pyudev": None}):
+            if "dicton.fn_key_handler" in sys.modules:
+                del sys.modules["dicton.fn_key_handler"]
+
+            from dicton.fn_key_handler import FnKeyHandler
+
+            handler = FnKeyHandler()
+            # Should initialize successfully
+            assert handler._pending_refresh is not None
+            assert handler._devices_lock is not None
+
+    def test_pyudev_flag_initial_state(self, fn_handler):
+        """_pyudev_available should be False initially (set during start())."""
+        assert fn_handler._pyudev_available is False
+
+
+class TestMonitorPollTimeout:
+    """Test that monitor.poll uses timeout for clean shutdown."""
+
+    def test_poll_with_timeout_allows_shutdown(self, mock_evdev_module):
+        """Monitor loop should check _running after poll timeout."""
+        # Create a mock pyudev module
+        mock_monitor = MagicMock()
+        # First call returns None (timeout), second would block but we stop
+        mock_monitor.poll = MagicMock(side_effect=[None, None])
+
+        mock_context = MagicMock()
+        mock_pyudev = MagicMock()
+        mock_pyudev.Context.return_value = mock_context
+        mock_pyudev.Monitor.from_netlink.return_value = mock_monitor
+
+        with patch.dict(sys.modules, {"pyudev": mock_pyudev}):
+            if "dicton.fn_key_handler" in sys.modules:
+                del sys.modules["dicton.fn_key_handler"]
+
+            from dicton.fn_key_handler import FnKeyHandler
+
+            handler = FnKeyHandler()
+            handler._pyudev_available = True
+            handler._running = True
+
+            # Start monitor in thread
+            monitor_thread = threading.Thread(target=handler._device_monitor_loop, daemon=True)
+            monitor_thread.start()
+
+            # Give it time to call poll once
+            time.sleep(0.1)
+
+            # Signal shutdown
+            handler._running = False
+
+            # Thread should exit within poll timeout (1s) + some margin
+            monitor_thread.join(timeout=2.0)
+            assert not monitor_thread.is_alive(), "Monitor thread did not exit cleanly"
+
+    def test_monitor_handles_device_events(self, mock_evdev_module):
+        """Monitor should set _pending_refresh on device add/remove."""
+        mock_device = MagicMock()
+        mock_device.device_node = "/dev/input/event99"
+        mock_device.action = "add"
+
+        mock_monitor = MagicMock()
+        # Return device, then None to exit
+        mock_monitor.poll = MagicMock(side_effect=[mock_device, None, None])
+
+        mock_context = MagicMock()
+        mock_pyudev = MagicMock()
+        mock_pyudev.Context.return_value = mock_context
+        mock_pyudev.Monitor.from_netlink.return_value = mock_monitor
+
+        with patch.dict(sys.modules, {"pyudev": mock_pyudev}):
+            if "dicton.fn_key_handler" in sys.modules:
+                del sys.modules["dicton.fn_key_handler"]
+
+            from dicton.fn_key_handler import FnKeyHandler
+
+            handler = FnKeyHandler()
+            handler._pyudev_available = True
+            handler._running = True
+
+            # Mock _wake_select to avoid pipe issues
+            handler._wake_select = MagicMock()
+
+            # Start monitor in thread
+            monitor_thread = threading.Thread(target=handler._device_monitor_loop, daemon=True)
+            monitor_thread.start()
+
+            # Give it time to process
+            time.sleep(0.2)
+
+            # Stop and wait
+            handler._running = False
+            monitor_thread.join(timeout=2.0)
+
+            # Should have set pending refresh
+            assert handler._pending_refresh.is_set()
+            # Should have called wake_select
+            handler._wake_select.assert_called()


### PR DESCRIPTION
## Summary

- Automatically detect keyboard plug/unplug events without requiring `systemctl restart dicton`
- Uses pyudev to monitor `/dev/input/` for device changes
- Self-pipe pattern to wake `select()` loop when devices change
- Gracefully degrades if pyudev not installed (hot-plug disabled, but everything else works)

## Technical Details

**New components:**
- `_device_monitor_loop()` - pyudev event loop monitoring input subsystem
- `_refresh_devices()` - Thread-safe device enumeration refresh
- `_wake_select()` / `_close_wake_pipe()` - Self-pipe for inter-thread signaling
- `_devices_lock` - Protects device list access across threads

**Flow:**
```
Keyboard plugged/unplugged
       ↓
pyudev monitor detects event
       ↓
Sets _pending_refresh, writes to wake pipe
       ↓
select() wakes, listener checks flag
       ↓
_refresh_devices() closes old, opens new
       ↓
Continues listening on updated device set
```

## Test plan

- [ ] Verify hot-plug works: unplug external keyboard, plug back in, FN key still works
- [ ] Verify graceful degradation: uninstall pyudev, confirm app starts without hot-plug
- [ ] Verify no regression: FN key, secondary hotkeys, custom hotkeys all work as before
- [ ] Verify DEBUG mode logs device changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)