### PR TITLE
feat: disable desktop notifications by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,15 @@ VISUALIZER_BACKEND=pygame
 VISUALIZER_OPACITY=0.85
 
 # =============================================================================
+# Desktop Notifications
+# =============================================================================
+
+# Enable desktop notifications for recording start/stop/errors
+# Disabled by default since the visualizer provides sufficient visual feedback
+# Set to "true" if you prefer desktop notification popups
+NOTIFICATIONS_ENABLED=false
+
+# =============================================================================
 # Audio & Language Settings
 # =============================================================================
 

--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -198,6 +198,10 @@ class Config:
 
     DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 
+    # Desktop notifications - show notifications for recording start/stop/errors
+    # Disabled by default since the visualizer provides sufficient feedback
+    NOTIFICATIONS_ENABLED = os.getenv("NOTIFICATIONS_ENABLED", "false").lower() == "true"
+
     # Context detection - adapts LLM prompts and typing speed based on active app
     CONTEXT_ENABLED = os.getenv("CONTEXT_ENABLED", "true").lower() == "true"
 

--- a/src/dicton/ui_feedback.py
+++ b/src/dicton/ui_feedback.py
@@ -2,11 +2,18 @@
 
 import subprocess
 
+from .config import Config
 from .platform_utils import IS_LINUX, IS_MACOS, IS_WINDOWS
 
 
 def notify(title: str, message: str, timeout: int = 2):
-    """Show desktop notification - cross-platform"""
+    """Show desktop notification - cross-platform.
+
+    Respects NOTIFICATIONS_ENABLED config setting (disabled by default).
+    """
+    if not Config.NOTIFICATIONS_ENABLED:
+        return
+
     try:
         if IS_LINUX:
             _notify_linux(title, message, timeout)


### PR DESCRIPTION
## Summary

- Disables desktop notifications by default since the visualizer provides sufficient visual feedback
- Adds `NOTIFICATIONS_ENABLED` config option for users who prefer notification popups
- Documents the new setting in `.env.example`

## Changes

- `src/dicton/config.py`: Added `NOTIFICATIONS_ENABLED` option (defaults to `false`)
- `src/dicton/ui_feedback.py`: Early return in `notify()` when disabled
- `.env.example`: Documented the new setting

## Test plan

- [x] Verify no notifications appear on hotkey press/release with default config
- [x] Verify notifications appear when `NOTIFICATIONS_ENABLED=true` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)