### PR TITLE
fix: eliminate clipboard race condition by removing restore logic

### DIFF
--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -212,8 +212,6 @@ class Config:
     CLIPBOARD_VERIFY_DELAY_MS = int(os.getenv("CLIPBOARD_VERIFY_DELAY_MS", "50"))
     # Max attempts to verify clipboard was set correctly before giving up
     CLIPBOARD_MAX_RETRIES = int(os.getenv("CLIPBOARD_MAX_RETRIES", "5"))
-    # Delay before restoring original clipboard after paste (ms)
-    CLIPBOARD_RESTORE_DELAY_MS = int(os.getenv("CLIPBOARD_RESTORE_DELAY_MS", "250"))
 
     DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 


### PR DESCRIPTION
## Summary

- **Removes clipboard save/restore entirely** — the previous approach (save original → paste → delay → restore) had an inherent race condition: the timing-sensitive restore delay was always a guess, causing intermittent failures where the target app read the restored old content instead of the transcription.
- **Transcription stays in clipboard after paste** — if the initial paste misses the target (wrong focus, app not ready), the user can simply Ctrl+V to re-paste. No more lost transcriptions.
- **Removes `_compute_restore_delay()`** and `CLIPBOARD_RESTORE_DELAY_MS` config — no longer needed since there's no restore timing to manage.
- **Keeps `_verify_clipboard()`** — still needed to confirm X11 clipboard propagation before sending the paste keystroke.
- Applied to all three paste paths: `_paste_text_linux`, `_replace_selection_linux`, `_replace_selection_windows`.
- Net result: ~60 fewer lines of timing-sensitive code.

## Trade-off

The user's original clipboard content is replaced by the transcription. This is an acceptable trade-off for guaranteed reliability — dictation is the primary workflow, and having the transcription always available in clipboard is more useful than preserving the previous clipboard content.

## Test plan

- [ ] Dictate a long paragraph (100+ words) and verify correct text is pasted
- [ ] Dictate in an Electron app (VS Code, Slack) — previously the most failure-prone
- [ ] Verify Ctrl+V works after dictation to re-paste the transcription
- [ ] Test Act on Text mode (FN+Shift) with replacement text
- [ ] Confirm clipboard contains transcription after paste (not old content)