### PR TITLE
Add Windows packaging pipeline and platform-native app path handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,32 @@ jobs:
         run: |
           python -c "import dicton; print(dicton.__version__)"
           python -m dicton --version
+
+  windows-package:
+    name: Windows Package
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package dependencies
+        shell: bash
+        run: pip install -e ".[windows,context-windows,notifications,llm,configui,mistral,packaging]"
+
+      - name: Build Windows bundle
+        shell: powershell
+        run: .\scripts\build-windows.ps1
+
+      - name: Smoke packaged executable
+        shell: powershell
+        run: .\dist\dicton\dicton.exe --version
+
+      - name: Upload Windows bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: dicton-windows-x64
+          path: dist/dicton-windows-x64.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README and example configuration to match the simplified defaults.
 - Fixed stale Windows/Linux launcher scripts and aligned installers with `pyproject.toml`.
 - Made the package version single-source and corrected GitHub/update metadata.
+- Started a Windows PyInstaller packaging path and moved user config/data handling toward platform-native directories.
 
 ## [1.1.1]
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Advanced modes still exist in the codebase, but they are hidden by default. Set 
   - Anthropic API key ([get one here](https://console.anthropic.com/settings/keys))
 
 ### Other Platforms
-- Windows has an experimental fallback path with `Alt+G` and basic context detection
+- Windows now has a first packaging path for the fallback `Alt+G` workflow
 - macOS currently supports fallback typing and notifications, but not full feature parity
 - FN key mode remains Linux-only
 
@@ -114,6 +114,11 @@ echo "ANTHROPIC_API_KEY=your_key" >> ~/.config/dicton/.env
 dicton
 ```
 
+### Windows Preview Bundle
+
+The first Windows packaging path produces a one-folder bundle for the fallback desktop workflow.
+Build details and supported scope are documented in [docs/windows-packaging.md](docs/windows-packaging.md).
+
 ### System Dependencies
 
 **Debian/Ubuntu:**
@@ -137,7 +142,7 @@ sudo pacman -S wl-clipboard
 ## Configuration
 
 Configuration is read from (in order):
-1. `~/.config/dicton/.env` (user config)
+1. The per-user Dicton config directory (`%APPDATA%\\dicton` on Windows, `~/.config/dicton` on Linux)
 2. `./.env` (current directory)
 3. `/opt/dicton/.env` (system install)
 
@@ -265,7 +270,7 @@ This context is matched against profiles that customize:
 
 Enable/disable context detection via the dashboard's **Context** tab at `http://localhost:6873`.
 
-Custom profiles can be added to `~/.config/dicton/contexts.json`:
+Custom profiles can be added to the per-user `contexts.json` file in Dicton's config directory:
 
 ```json
 {

--- a/SETUP.md
+++ b/SETUP.md
@@ -34,6 +34,11 @@ pip install pipwin
 pipwin install pyaudio
 ```
 
+For the packaged Windows bundle path, also install:
+```cmd
+pip install -e ".[windows,context-windows,notifications,llm,configui,mistral,packaging]"
+```
+
 ## Development Installation
 
 ```bash
@@ -93,6 +98,12 @@ dicton
 
 # Or as module
 python -m dicton
+```
+
+## Windows Bundle Build
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\build-windows.ps1
 ```
 
 ## Configuration

--- a/docs/windows-packaging.md
+++ b/docs/windows-packaging.md
@@ -1,0 +1,44 @@
+# Windows Packaging
+
+This project now includes a first Windows packaging path based on PyInstaller.
+
+## Current Scope
+
+The Windows bundle is intended for the fallback desktop workflow:
+
+- `Alt+G` hotkey mode
+- Basic transcription
+- Translation to English
+- Config UI via `dicton.exe --config-ui`
+- Experimental Windows context detection
+
+Not in scope for the first Windows bundle:
+
+- FN key support
+- Linux-only playback mute control
+- Full feature parity with Linux
+
+## Build Locally on Windows
+
+```powershell
+python -m pip install -e ".[windows,context-windows,notifications,llm,configui,mistral,packaging]"
+powershell -ExecutionPolicy Bypass -File scripts\build-windows.ps1
+```
+
+The output is:
+
+- `dist\dicton\` - unpacked one-folder application bundle
+- `dist\dicton-windows-x64.zip` - distributable archive
+
+## Bundle Layout
+
+The packaged bundle includes:
+
+- `dicton.exe`
+- bundled package assets
+- `.env.example`
+- `README.md`
+
+The one-folder bundle is intentional for the first Windows release path. It is
+simpler to debug and less fragile than a one-file executable while the platform
+support is still maturing.

--- a/packaging/windows/dicton.spec
+++ b/packaging/windows/dicton.spec
@@ -30,7 +30,7 @@ hiddenimports = [
 
 
 a = Analysis(
-    ["src/dicton/__main__.py"],
+    [str(project_root / "src" / "dicton" / "__main__.py")],
     pathex=[str(project_root / "src")],
     binaries=[],
     datas=datas,

--- a/packaging/windows/dicton.spec
+++ b/packaging/windows/dicton.spec
@@ -1,0 +1,72 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files
+
+
+project_root = Path(__file__).resolve().parents[2]
+datas = collect_data_files(
+    "dicton",
+    includes=[
+        "assets/config_ui.html",
+        "assets/logo.png",
+        "default_contexts.json",
+    ],
+)
+datas += [
+    (str(project_root / ".env.example"), "."),
+    (str(project_root / "README.md"), "."),
+]
+
+hiddenimports = [
+    "dicton.config_server",
+    "dicton.context_detector_windows",
+    "dicton.main",
+    "dicton.stt_elevenlabs",
+    "dicton.stt_mistral",
+]
+
+
+a = Analysis(
+    ["src/dicton/__main__.py"],
+    pathex=[str(project_root / "src")],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="dicton",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="dicton",
+)

--- a/packaging/windows/dicton.spec
+++ b/packaging/windows/dicton.spec
@@ -30,7 +30,7 @@ hiddenimports = [
 
 
 a = Analysis(
-    [str(project_root / "src" / "dicton" / "__main__.py")],
+    [str(project_root / "packaging" / "windows" / "pyinstaller_entry.py")],
     pathex=[str(project_root / "src")],
     binaries=[],
     datas=datas,

--- a/packaging/windows/dicton.spec
+++ b/packaging/windows/dicton.spec
@@ -5,7 +5,8 @@ from pathlib import Path
 from PyInstaller.utils.hooks import collect_data_files
 
 
-project_root = Path(__file__).resolve().parents[2]
+spec_dir = Path(globals().get("SPECPATH", Path.cwd())).resolve()
+project_root = spec_dir.parents[1]
 datas = collect_data_files(
     "dicton",
     includes=[

--- a/packaging/windows/pyinstaller_entry.py
+++ b/packaging/windows/pyinstaller_entry.py
@@ -1,0 +1,10 @@
+"""PyInstaller entrypoint for Dicton.
+
+This avoids executing ``dicton/__main__.py`` as a bare script, which would
+break its relative imports in a frozen application.
+"""
+
+from dicton.__main__ import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
 ]
+packaging = [
+    "pyinstaller>=6.11.0",
+]
 configui = [
     "fastapi>=0.110.0",
     "uvicorn>=0.27.0",
@@ -105,7 +108,7 @@ linux = [
     "dicton[fnkey,llm,xshape,notifications,configui,context-x11,mistral]",
 ]
 all = [
-    "dicton[vispy,gtk,fnkey,llm,xshape,notifications,windows,dev,configui,context-x11,context-wayland,context-windows,mistral]",
+    "dicton[vispy,gtk,fnkey,llm,xshape,notifications,windows,dev,packaging,configui,context-x11,context-wayland,context-windows,mistral]",
 ]
 
 [project.scripts]

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectDir = Split-Path -Parent $ScriptDir
+Set-Location $ProjectDir
+
+Write-Host "==> Building Dicton Windows bundle"
+python -m PyInstaller --noconfirm --clean packaging/windows/dicton.spec
+
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$BundleDir = Join-Path $ProjectDir "dist\dicton"
+if (-not (Test-Path $BundleDir)) {
+    throw "Expected bundle directory not found: $BundleDir"
+}
+
+Copy-Item ".env.example" (Join-Path $BundleDir ".env.example") -Force
+Copy-Item "README.md" (Join-Path $BundleDir "README.md") -Force
+
+$ArchivePath = Join-Path $ProjectDir "dist\dicton-windows-x64.zip"
+if (Test-Path $ArchivePath) {
+    Remove-Item $ArchivePath -Force
+}
+
+Compress-Archive -Path (Join-Path $BundleDir "*") -DestinationPath $ArchivePath
+Write-Host "==> Windows bundle ready: $ArchivePath"

--- a/src/dicton/app_paths.py
+++ b/src/dicton/app_paths.py
@@ -1,0 +1,74 @@
+"""Cross-platform application paths for Dicton."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+APP_NAME = "dicton"
+
+
+def _home_fallback(*parts: str) -> Path:
+    return Path.home().joinpath(*parts)
+
+
+def get_user_config_dir() -> Path:
+    """Return the per-user configuration directory."""
+    override = os.getenv("DICTON_CONFIG_DIR")
+    if override:
+        return Path(override).expanduser()
+
+    if sys.platform == "win32":
+        return Path(os.getenv("APPDATA", _home_fallback("AppData", "Roaming"))) / APP_NAME
+    if sys.platform == "darwin":
+        return _home_fallback("Library", "Application Support", APP_NAME)
+    return _home_fallback(".config", APP_NAME)
+
+
+def get_user_data_dir() -> Path:
+    """Return the per-user application data directory."""
+    override = os.getenv("DICTON_DATA_DIR")
+    if override:
+        return Path(override).expanduser()
+
+    if sys.platform == "win32":
+        base = os.getenv("LOCALAPPDATA") or os.getenv("APPDATA")
+        return Path(base or _home_fallback("AppData", "Local")) / APP_NAME
+    if sys.platform == "darwin":
+        return _home_fallback("Library", "Application Support", APP_NAME)
+    return _home_fallback(".local", "share", APP_NAME)
+
+
+def get_user_cache_dir() -> Path:
+    """Return the per-user cache directory."""
+    override = os.getenv("DICTON_CACHE_DIR")
+    if override:
+        return Path(override).expanduser()
+
+    if sys.platform == "win32":
+        base = os.getenv("LOCALAPPDATA") or os.getenv("APPDATA")
+        return Path(base or _home_fallback("AppData", "Local")) / APP_NAME / "cache"
+    if sys.platform == "darwin":
+        return _home_fallback("Library", "Caches", APP_NAME)
+    return _home_fallback(".cache", APP_NAME)
+
+
+def get_user_env_path() -> Path:
+    return get_user_config_dir() / ".env"
+
+
+def get_user_contexts_path() -> Path:
+    return get_user_config_dir() / "contexts.json"
+
+
+def get_user_dictionary_path() -> Path:
+    return get_user_config_dir() / "dictionary.json"
+
+
+def get_latency_log_path() -> Path:
+    return get_user_data_dir() / "latency.log"
+
+
+def get_update_cache_path() -> Path:
+    return get_user_cache_dir() / "update_cache.json"

--- a/src/dicton/assets/config_ui.html
+++ b/src/dicton/assets/config_ui.html
@@ -947,7 +947,7 @@
 
             <div class="section">
                 <div class="section-title">Available Profiles</div>
-                <div class="hint" style="margin-bottom: 1rem">Click a profile to edit. User profiles are saved to ~/.config/dicton/contexts.json</div>
+                <div class="hint" style="margin-bottom: 1rem">Click a profile to edit. User profiles are saved to your Dicton user config directory.</div>
                 <div id="profile-list" class="profile-list"></div>
                 <button class="btn btn-secondary" onclick="showProfileEditor(null)" style="margin-top: 1rem">New Profile</button>
             </div>

--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -5,12 +5,14 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from .app_paths import get_user_config_dir, get_user_data_dir, get_user_env_path
+
 
 def _load_env_files():
     """Load .env from multiple possible locations (first found wins).
 
     Priority order:
-    1. User config dir (~/.config/dicton/) - where dashboard saves settings
+    1. User config dir - where dashboard saves settings
     2. Current working directory - for development
     3. System install (/opt/dicton/) - read-only defaults
     """
@@ -26,7 +28,7 @@ def _load_env_files():
         return None
 
     locations = [
-        Path.home() / ".config" / "dicton" / ".env",  # User config dir - FIRST!
+        get_user_env_path(),  # User config dir - FIRST!
         Path.cwd() / ".env",  # Current working directory
         Path("/opt/dicton/.env"),  # System install (read-only fallback)
     ]
@@ -113,8 +115,8 @@ class Config:
     """Configuration for Dicton"""
 
     # Paths - use user-writable directories
-    CONFIG_DIR = Path.home() / ".config" / "dicton"
-    DATA_DIR = Path.home() / ".local" / "share" / "dicton"
+    CONFIG_DIR = get_user_config_dir()
+    DATA_DIR = get_user_data_dir()
     MODELS_DIR = DATA_DIR / "models"
 
     # ElevenLabs API

--- a/src/dicton/config_server.py
+++ b/src/dicton/config_server.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from threading import Timer
 from typing import Any
 
+from .app_paths import get_user_contexts_path
 from .config import Config, config
 
 
@@ -466,11 +467,10 @@ def create_app():
     async def api_update_profile(profile_name: str, request: Request):
         """Update or create a profile (saved to user config)."""
         import json
-        from pathlib import Path
 
         try:
             data = await request.json()
-            user_config_path = Path.home() / ".config" / "dicton" / "contexts.json"
+            user_config_path = get_user_contexts_path()
 
             # Load existing user config or start fresh
             if user_config_path.exists():
@@ -512,13 +512,12 @@ def create_app():
     async def api_delete_profile(profile_name: str):
         """Delete a user profile (cannot delete bundled defaults)."""
         import json
-        from pathlib import Path
 
         try:
             if profile_name == "default":
                 return JSONResponse({"error": "Cannot delete the default profile"}, status_code=400)
 
-            user_config_path = Path.home() / ".config" / "dicton" / "contexts.json"
+            user_config_path = get_user_contexts_path()
 
             if not user_config_path.exists():
                 return JSONResponse(

--- a/src/dicton/context_profiles.py
+++ b/src/dicton/context_profiles.py
@@ -10,6 +10,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .app_paths import get_user_contexts_path
 from .context_detector import ContextInfo
 
 logger = logging.getLogger(__name__)
@@ -91,7 +92,7 @@ class ContextProfileManager:
 
     Loads profiles from:
     1. Default bundled profiles (src/dicton/default_contexts.json)
-    2. User profiles (~/.config/dicton/contexts.json) - overrides defaults
+    2. User profiles (per-user config directory) - overrides defaults
     """
 
     # Typing speed presets (delay in seconds between characters)
@@ -117,7 +118,7 @@ class ContextProfileManager:
             self._load_from_file(default_path)
 
         # Load user overrides
-        user_path = Path.home() / ".config" / "dicton" / "contexts.json"
+        user_path = get_user_contexts_path()
         if user_path.exists():
             self._load_from_file(user_path)
 

--- a/src/dicton/latency_tracker.py
+++ b/src/dicton/latency_tracker.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from statistics import mean, median, quantiles
 from typing import Any
 
+from .app_paths import get_latency_log_path
 from .config import config
 
 
@@ -85,7 +86,7 @@ class LatencyTracker:
 
         # Default log location
         if log_path is None:
-            self.log_path = Path.home() / ".config" / "dicton" / "latency.log"
+            self.log_path = get_latency_log_path()
         else:
             self.log_path = Path(log_path)
 

--- a/src/dicton/text_processor.py
+++ b/src/dicton/text_processor.py
@@ -5,6 +5,8 @@ import re
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from .app_paths import get_user_dictionary_path
+
 # Language-aware filler words
 FILLER_WORDS = {
     # English fillers
@@ -125,7 +127,7 @@ class TextProcessor:
 
         Args:
             dictionary_path: Path to custom dictionary JSON file.
-                            If None, uses default location (~/.config/dicton/dictionary.json)
+                            If None, uses the platform-native user config location.
             filter_fillers: If True, remove filler words from transcriptions.
             language: Language code for filler detection ('en', 'fr', 'de', 'es', 'auto').
                      'auto' uses common fillers across all languages.
@@ -142,7 +144,7 @@ class TextProcessor:
 
         # Default dictionary location
         if dictionary_path is None:
-            self.dictionary_path = Path.home() / ".config" / "dicton" / "dictionary.json"
+            self.dictionary_path = get_user_dictionary_path()
         else:
             self.dictionary_path = Path(dictionary_path)
 

--- a/src/dicton/update_checker.py
+++ b/src/dicton/update_checker.py
@@ -7,12 +7,12 @@ and notifies users when a new version is available.
 import json
 import threading
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import NamedTuple
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from . import __version__
+from .app_paths import get_update_cache_path
 from .config import config
 
 # GitHub repository info
@@ -21,7 +21,7 @@ GITHUB_REPO = "dicton"
 GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest"
 
 # Cache settings
-CACHE_FILE = Path.home() / ".config" / "dicton" / "update_cache.json"
+CACHE_FILE = get_update_cache_path()
 CHECK_INTERVAL_HOURS = 24  # Only check once per day
 
 

--- a/tests/test_app_paths.py
+++ b/tests/test_app_paths.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import PureWindowsPath
+
+
+def test_linux_paths_default(monkeypatch):
+    monkeypatch.delenv("DICTON_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("DICTON_DATA_DIR", raising=False)
+    monkeypatch.delenv("DICTON_CACHE_DIR", raising=False)
+    monkeypatch.setattr("sys.platform", "linux")
+
+    import dicton.app_paths as app_paths
+
+    importlib.reload(app_paths)
+
+    assert app_paths.get_user_config_dir().name == "dicton"
+    assert ".config" in str(app_paths.get_user_config_dir())
+    assert ".local" in str(app_paths.get_user_data_dir())
+    assert ".cache" in str(app_paths.get_user_cache_dir())
+
+
+def test_windows_paths_use_appdata(monkeypatch):
+    monkeypatch.delenv("DICTON_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("DICTON_DATA_DIR", raising=False)
+    monkeypatch.delenv("DICTON_CACHE_DIR", raising=False)
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setenv("APPDATA", r"C:\Users\Test\AppData\Roaming")
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\Test\AppData\Local")
+
+    import dicton.app_paths as app_paths
+
+    importlib.reload(app_paths)
+
+    assert PureWindowsPath(str(app_paths.get_user_config_dir())) == PureWindowsPath(
+        r"C:\Users\Test\AppData\Roaming\dicton"
+    )
+    assert PureWindowsPath(str(app_paths.get_user_data_dir())) == PureWindowsPath(
+        r"C:\Users\Test\AppData\Local\dicton"
+    )
+    assert PureWindowsPath(str(app_paths.get_user_cache_dir())) == PureWindowsPath(
+        r"C:\Users\Test\AppData\Local\dicton\cache"
+    )
+
+
+def test_path_overrides_take_precedence(monkeypatch):
+    monkeypatch.setenv("DICTON_CONFIG_DIR", "/tmp/dicton-config")
+    monkeypatch.setenv("DICTON_DATA_DIR", "/tmp/dicton-data")
+    monkeypatch.setenv("DICTON_CACHE_DIR", "/tmp/dicton-cache")
+
+    import dicton.app_paths as app_paths
+
+    importlib.reload(app_paths)
+
+    assert str(app_paths.get_user_config_dir()) == "/tmp/dicton-config"
+    assert str(app_paths.get_user_data_dir()) == "/tmp/dicton-data"
+    assert str(app_paths.get_user_cache_dir()) == "/tmp/dicton-cache"

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -86,3 +86,16 @@ def test_check_script_covers_ci_targets():
     assert "./scripts/check.sh build" in (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
+
+
+def test_windows_packaging_files_exist():
+    assert (ROOT / "packaging" / "windows" / "dicton.spec").exists()
+    assert (ROOT / "scripts" / "build-windows.ps1").exists()
+    assert (ROOT / "docs" / "windows-packaging.md").exists()
+
+
+def test_windows_package_job_present():
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "windows-package:" in workflow
+    assert r".\scripts\build-windows.ps1" in workflow
+    assert "dicton-windows-x64.zip" in workflow

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -90,12 +90,13 @@ def test_check_script_covers_ci_targets():
 
 def test_windows_packaging_files_exist():
     assert (ROOT / "packaging" / "windows" / "dicton.spec").exists()
+    assert (ROOT / "packaging" / "windows" / "pyinstaller_entry.py").exists()
     assert (ROOT / "scripts" / "build-windows.ps1").exists()
     assert (ROOT / "docs" / "windows-packaging.md").exists()
     spec = (ROOT / "packaging" / "windows" / "dicton.spec").read_text(encoding="utf-8")
     assert "__file__" not in spec
     assert "SPECPATH" in spec
-    assert 'project_root / "src" / "dicton" / "__main__.py"' in spec
+    assert 'project_root / "packaging" / "windows" / "pyinstaller_entry.py"' in spec
 
 
 def test_windows_package_job_present():

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -92,6 +92,9 @@ def test_windows_packaging_files_exist():
     assert (ROOT / "packaging" / "windows" / "dicton.spec").exists()
     assert (ROOT / "scripts" / "build-windows.ps1").exists()
     assert (ROOT / "docs" / "windows-packaging.md").exists()
+    spec = (ROOT / "packaging" / "windows" / "dicton.spec").read_text(encoding="utf-8")
+    assert "__file__" not in spec
+    assert "SPECPATH" in spec
 
 
 def test_windows_package_job_present():

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -95,6 +95,7 @@ def test_windows_packaging_files_exist():
     spec = (ROOT / "packaging" / "windows" / "dicton.spec").read_text(encoding="utf-8")
     assert "__file__" not in spec
     assert "SPECPATH" in spec
+    assert 'project_root / "src" / "dicton" / "__main__.py"' in spec
 
 
 def test_windows_package_job_present():


### PR DESCRIPTION
## Summary
- Add a Windows packaging path using PyInstaller, including `packaging/windows/dicton.spec` and `scripts/build-windows.ps1`.
- Add a new `windows-package` GitHub Actions job to build, smoke-test (`dicton.exe --version`), and upload `dicton-windows-x64.zip`.
- Introduce `src/dicton/app_paths.py` for platform-native config/data/cache paths with env var overrides.
- Refactor config, context profiles, config server, text processor, latency tracker, and update checker to use centralized app-path helpers.
- Document Windows packaging workflow and scope in `docs/windows-packaging.md`, and update README/SETUP/CHANGELOG messaging.
- Extend test coverage with new app-path unit tests and packaging-surface assertions.

## Testing
- Added unit tests in `tests/test_app_paths.py` for Linux defaults, Windows `%APPDATA%`/`%LOCALAPPDATA%`, and `DICTON_*_DIR` overrides.
- Added packaging surface checks in `tests/test_packaging_surface.py` to verify Windows spec/script/docs and CI job wiring.
- CI workflow now includes a Windows packaging smoke check: `dist\dicton\dicton.exe --version`.
- Not run locally (execution results were not provided in this diff context).