### PR TITLE
Add Linux packaging pipeline and tag-based GitHub release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,36 @@ jobs:
         with:
           name: dicton-windows-x64
           path: dist/dicton-windows-x64.zip
+
+  linux-package:
+    name: Linux Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev libportaudio2 xdotool xclip libnotify-bin
+
+      - name: Install package dependencies
+        run: pip install -e ".[linux,packaging]"
+
+      - name: Build Linux package assets
+        run: ./scripts/build-linux-package.sh
+
+      - name: Smoke packaged executable
+        run: ./dist/dicton/dicton --version
+
+      - name: Upload Linux bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: dicton-linux-x64
+          path: |
+            dist/dicton-linux-x64.tar.gz
+            dist/dicton_*_amd64.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  python-dist:
+    name: Python Dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build sdist and wheel
+        run: ./scripts/check.sh build
+
+      - name: Upload Python artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+
+  linux-package:
+    name: Linux Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev libportaudio2 xdotool xclip libnotify-bin
+
+      - name: Install package dependencies
+        run: pip install -e ".[linux,packaging]"
+
+      - name: Build Linux release assets
+        run: ./scripts/build-linux-package.sh
+
+      - name: Smoke packaged executable
+        run: ./dist/dicton/dicton --version
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-package
+          path: |
+            dist/dicton-linux-x64.tar.gz
+            dist/dicton_*_amd64.deb
+
+  windows-package:
+    name: Windows Package
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package dependencies
+        shell: bash
+        run: pip install -e ".[windows,context-windows,notifications,llm,configui,mistral,packaging]"
+
+      - name: Build Windows bundle
+        shell: powershell
+        run: .\scripts\build-windows.ps1
+
+      - name: Smoke packaged executable
+        shell: powershell
+        run: .\dist\dicton\dicton.exe --version
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-package
+          path: dist/dicton-windows-x64.zip
+
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: [python-dist, linux-package, windows-package]
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            release-artifacts/python-dist/*
+            release-artifacts/linux-package/*
+            release-artifacts/windows-package/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed stale Windows/Linux launcher scripts and aligned installers with `pyproject.toml`.
 - Made the package version single-source and corrected GitHub/update metadata.
 - Started a Windows PyInstaller packaging path and moved user config/data handling toward platform-native directories.
+- Added a Linux release package path and a tag-based GitHub release workflow that publishes Windows, Linux, and Python distribution assets.
 
 ## [1.1.1]
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ dicton
 The first Windows packaging path produces a one-folder bundle for the fallback desktop workflow.
 Build details and supported scope are documented in [docs/windows-packaging.md](docs/windows-packaging.md).
 
+### Linux Release Package
+
+Linux release builds now also produce:
+
+- a frozen bundle tarball
+- a Debian package installable with `apt install ./dicton_<version>_amd64.deb`
+
+Build details are documented in [docs/linux-packaging.md](docs/linux-packaging.md).
+
 ### System Dependencies
 
 **Debian/Ubuntu:**

--- a/SETUP.md
+++ b/SETUP.md
@@ -106,6 +106,12 @@ python -m dicton
 powershell -ExecutionPolicy Bypass -File scripts\build-windows.ps1
 ```
 
+## Linux Release Package Build
+
+```bash
+./scripts/build-linux-package.sh
+```
+
 ## Configuration
 
 Edit `.env` to customize behavior:

--- a/docs/linux-packaging.md
+++ b/docs/linux-packaging.md
@@ -1,0 +1,30 @@
+# Linux Packaging
+
+This project now includes a first Linux release package path alongside the
+existing Python package and installer script.
+
+## Current Release Assets
+
+The Linux release flow produces:
+
+- `dicton-linux-x64.tar.gz` - one-folder frozen bundle
+- `dicton_<version>_amd64.deb` - Debian package that installs the bundle under `/opt/dicton`
+
+## Build Locally on Linux
+
+```bash
+sudo apt-get update
+sudo apt-get install -y portaudio19-dev libportaudio2 xdotool xclip libnotify-bin
+python3 -m pip install -e ".[linux,packaging]"
+./scripts/build-linux-package.sh
+```
+
+## Install the Debian Package
+
+```bash
+sudo apt install ./dist/dicton_<version>_amd64.deb
+```
+
+This is the practical first step toward one-command Linux installs. It is not
+yet a hosted APT repository; it is a release asset that can be installed with
+`apt install ./...deb`.

--- a/packaging/linux/dicton.spec
+++ b/packaging/linux/dicton.spec
@@ -1,0 +1,74 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files
+
+
+spec_dir = Path(globals().get("SPECPATH", Path.cwd())).resolve()
+project_root = spec_dir.parents[1]
+datas = collect_data_files(
+    "dicton",
+    includes=[
+        "assets/config_ui.html",
+        "assets/logo.png",
+        "default_contexts.json",
+    ],
+)
+datas += [
+    (str(project_root / ".env.example"), "."),
+    (str(project_root / "README.md"), "."),
+]
+
+hiddenimports = [
+    "dicton.config_server",
+    "dicton.context_detector_wayland",
+    "dicton.context_detector_x11",
+    "dicton.main",
+    "dicton.stt_elevenlabs",
+    "dicton.stt_mistral",
+]
+
+
+a = Analysis(
+    [str(project_root / "packaging" / "windows" / "pyinstaller_entry.py")],
+    pathex=[str(project_root / "src")],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="dicton",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="dicton",
+)

--- a/scripts/build-linux-package.sh
+++ b/scripts/build-linux-package.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DIST_DIR="${PROJECT_DIR}/dist"
+STAGE_DIR="${PROJECT_DIR}/build/linux-deb"
+BUNDLE_DIR="${DIST_DIR}/dicton"
+
+cd "${PROJECT_DIR}"
+
+version="$(python3 - <<'PY'
+import re
+from pathlib import Path
+
+content = Path("src/dicton/__init__.py").read_text(encoding="utf-8")
+match = re.search(r'__version__\s*=\s*"([^"]+)"', content)
+if not match:
+    raise SystemExit("Unable to determine Dicton version")
+print(match.group(1))
+PY
+)"
+
+echo "==> Building Dicton Linux bundle"
+python3 -m PyInstaller --noconfirm --clean packaging/linux/dicton.spec
+
+if [[ ! -d "${BUNDLE_DIR}" ]]; then
+    echo "Expected bundle directory not found: ${BUNDLE_DIR}" >&2
+    exit 1
+fi
+
+tarball_path="${DIST_DIR}/dicton-linux-x64.tar.gz"
+echo "==> Creating Linux tarball: ${tarball_path}"
+tar -C "${DIST_DIR}" -czf "${tarball_path}" dicton
+
+echo "==> Creating Debian package staging area"
+rm -rf "${STAGE_DIR}"
+mkdir -p "${STAGE_DIR}/DEBIAN" "${STAGE_DIR}/opt/dicton" "${STAGE_DIR}/usr/bin"
+
+cp -a "${BUNDLE_DIR}/." "${STAGE_DIR}/opt/dicton/"
+
+cat > "${STAGE_DIR}/usr/bin/dicton" <<'EOF'
+#!/bin/sh
+exec /opt/dicton/dicton "$@"
+EOF
+chmod 0755 "${STAGE_DIR}/usr/bin/dicton"
+
+cat > "${STAGE_DIR}/DEBIAN/control" <<EOF
+Package: dicton
+Version: ${version}
+Section: utils
+Priority: optional
+Architecture: amd64
+Maintainer: asi0 flammeus <asi0@crqpt.com>
+Depends: libportaudio2, xdotool, libnotify-bin
+Recommends: xclip | wl-clipboard
+Description: Voice-to-text dictation with direct transcription and translation
+ Dicton is a desktop dictation tool focused on direct transcription and
+ translation to English, packaged here as a Linux one-folder bundle.
+EOF
+
+deb_path="${DIST_DIR}/dicton_${version}_amd64.deb"
+echo "==> Building Debian package: ${deb_path}"
+dpkg-deb --build --root-owner-group "${STAGE_DIR}" "${deb_path}"
+
+echo "==> Linux release assets ready:"
+echo "    ${tarball_path}"
+echo "    ${deb_path}"

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -104,3 +104,29 @@ def test_windows_package_job_present():
     assert "windows-package:" in workflow
     assert r".\scripts\build-windows.ps1" in workflow
     assert "dicton-windows-x64.zip" in workflow
+
+
+def test_linux_packaging_files_exist():
+    assert (ROOT / "packaging" / "linux" / "dicton.spec").exists()
+    assert (ROOT / "scripts" / "build-linux-package.sh").exists()
+    assert (ROOT / "docs" / "linux-packaging.md").exists()
+    spec = (ROOT / "packaging" / "linux" / "dicton.spec").read_text(encoding="utf-8")
+    assert 'project_root / "packaging" / "windows" / "pyinstaller_entry.py"' in spec
+
+
+def test_linux_package_job_present():
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "linux-package:" in workflow
+    assert "./scripts/build-linux-package.sh" in workflow
+    assert "dicton-linux-x64.tar.gz" in workflow
+    assert "dicton_*_amd64.deb" in workflow
+
+
+def test_release_workflow_present():
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "tags:" in workflow
+    assert "v*" in workflow
+    assert "softprops/action-gh-release" in workflow
+    assert "windows-package" in workflow
+    assert "linux-package" in workflow
+    assert "python-dist" in workflow


### PR DESCRIPTION
## Summary
- add a Linux packaging path that builds both `dicton-linux-x64.tar.gz` and `dicton_<version>_amd64.deb`
- add `packaging/linux/dicton.spec` and `scripts/build-linux-package.sh` to produce frozen bundle and Debian package artifacts
- extend CI with a `linux-package` job that installs Linux deps, builds assets, runs a packaged binary smoke check, and uploads artifacts
- add a new tag-triggered `.github/workflows/release.yml` workflow to build Python, Linux, and Windows artifacts and publish a GitHub Release
- document Linux packaging in `README.md`, `SETUP.md`, and `docs/linux-packaging.md`, and note the change in `CHANGELOG.md`
- add packaging surface tests covering Linux packaging files, CI Linux job presence, and release workflow structure

## Testing
- Added/updated automated checks in `tests/test_packaging_surface.py` for:
- Linux packaging files and expected spec wiring
- CI Linux packaging job and expected artifact names
- release workflow trigger (`v*`) and required jobs/actions
- Not run: full Linux package build (`./scripts/build-linux-package.sh`) in local environment
- Not run: end-to-end GitHub Actions execution for tag-triggered release publishing