### PR TITLE
Add lightweight `--config-ui` CLI path and include PyInstaller hidden imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It is built for speed and low friction: press a hotkey, talk, release, and the t
 
 Download the latest release here:
 
-`https://github.com/Asi0Flammeus/dicton/releases/latest`
+[Latest release](https://github.com/Asi0Flammeus/dicton/releases/latest)
 
 ### Linux
 
@@ -115,7 +115,7 @@ GEMINI_API_KEY=your_key_here
 
 ## Releases
 
-- Latest release: `https://github.com/Asi0Flammeus/dicton/releases/latest`
+- Latest release: [https://github.com/Asi0Flammeus/dicton/releases/latest](https://github.com/Asi0Flammeus/dicton/releases/latest)
 - All releases: `https://github.com/Asi0Flammeus/dicton/releases`
 
 ## Development

--- a/packaging/linux/dicton.spec
+++ b/packaging/linux/dicton.spec
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 
 spec_dir = Path(globals().get("SPECPATH", Path.cwd())).resolve()
@@ -28,6 +28,8 @@ hiddenimports = [
     "dicton.stt_elevenlabs",
     "dicton.stt_mistral",
 ]
+hiddenimports += collect_submodules("pynput")
+hiddenimports += collect_submodules("Xlib")
 
 
 a = Analysis(

--- a/packaging/windows/dicton.spec
+++ b/packaging/windows/dicton.spec
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 
 spec_dir = Path(globals().get("SPECPATH", Path.cwd())).resolve()
@@ -27,6 +27,7 @@ hiddenimports = [
     "dicton.stt_elevenlabs",
     "dicton.stt_mistral",
 ]
+hiddenimports += collect_submodules("pynput")
 
 
 a = Analysis(

--- a/src/dicton/__main__.py
+++ b/src/dicton/__main__.py
@@ -2,15 +2,34 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 
 from . import __version__
 
 
+def _run_config_ui(argv: list[str]) -> None:
+    """Launch the config UI without importing the full app stack."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--config-ui", action="store_true")
+    parser.add_argument("--config-port", type=int, default=6873)
+    args, _ = parser.parse_known_args(argv)
+
+    from .config_server import run_config_server
+
+    run_config_server(port=args.config_port)
+
+
 def main() -> None:
     """Dispatch the CLI while keeping ``--version`` lightweight."""
-    if "--version" in sys.argv[1:]:
+    argv = sys.argv[1:]
+
+    if "--version" in argv:
         print(f"Dicton v{__version__}")
+        return
+
+    if "--config-ui" in argv:
+        _run_config_ui(argv)
         return
 
     from .main import main as app_main

--- a/src/dicton/main.py
+++ b/src/dicton/main.py
@@ -5,32 +5,36 @@ import os
 import signal
 import threading
 import warnings
+from typing import TYPE_CHECKING
 
 # Suppress warnings
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 warnings.filterwarnings("ignore")
 
-from .adapters.audio import AudioCaptureAdapter, STTAdapter
-from .adapters.audio_session_control import AudioSessionControlAdapter
 from .adapters.config_env import load_app_config
-from .adapters.metrics import MetricsAdapter
-from .adapters.text_processing import TextOutputAdapter, TextProcessorAdapter
-from .adapters.ui_feedback import UIFeedbackAdapter
 from .config import config
-from .context_detector import ContextInfo, get_context_detector
-from .core.controller import DictationController, SessionContext
-from .keyboard_handler import KeyboardHandler
-from .latency_tracker import get_latency_tracker
+from .core.controller import SessionContext
 from .platform_utils import IS_LINUX, IS_WINDOWS
 from .processing_mode import ProcessingMode, get_mode_color, is_mode_enabled
-from .speech_recognition_engine import SpeechRecognizer
-from .ui_feedback import notify
+
+if TYPE_CHECKING:
+    from .context_detector import ContextInfo
 
 
 class Dicton:
     """Main application with FN key hotkey and processing modes"""
 
     def __init__(self):
+        from .adapters.audio import AudioCaptureAdapter, STTAdapter
+        from .adapters.audio_session_control import AudioSessionControlAdapter
+        from .adapters.metrics import MetricsAdapter
+        from .adapters.text_processing import TextOutputAdapter, TextProcessorAdapter
+        from .adapters.ui_feedback import UIFeedbackAdapter
+        from .core.controller import DictationController
+        from .keyboard_handler import KeyboardHandler
+        from .latency_tracker import get_latency_tracker
+        from .speech_recognition_engine import SpeechRecognizer
+
         config.create_dirs()
         self.recognizer = SpeechRecognizer()
 
@@ -117,6 +121,8 @@ class Dicton:
         # Detect context at recording start (not on every frame)
         if self._app_config.context_enabled:
             try:
+                from .context_detector import get_context_detector
+
                 detector = get_context_detector()
                 if detector:
                     self._current_context = detector.get_context()
@@ -254,6 +260,8 @@ class Dicton:
 
         except Exception as e:
             print(f"Error: {e}")
+            from .ui_feedback import notify
+
             notify("❌ Error", str(e)[:50])
             try:
                 tracker.end_session()
@@ -273,6 +281,8 @@ class Dicton:
 
             if not has_selection():
                 print("⚠ No text selected")
+                from .ui_feedback import notify
+
                 notify("⚠ No Selection", "Highlight text first, then press FN+Shift")
                 return None
 
@@ -280,6 +290,8 @@ class Dicton:
             if not selected:
                 tool_hint = "wl-clipboard" if IS_WAYLAND else "xclip"
                 print(f"⚠ Could not read selection (install {tool_hint})")
+                from .ui_feedback import notify
+
                 notify("⚠ Selection Error", f"Install {tool_hint}")
                 return None
 
@@ -287,6 +299,8 @@ class Dicton:
 
         except ImportError as e:
             print(f"⚠ Selection handler not available: {e}")
+            from .ui_feedback import notify
+
             notify("⚠ Not Available", "Install xclip or wl-clipboard")
             return None
 
@@ -295,7 +309,7 @@ class Dicton:
         text: str,
         mode: ProcessingMode,
         selected_text: str | None = None,
-        context: ContextInfo | None = None,
+        context: "ContextInfo | None" = None,
     ) -> str | None:
         """Process transcribed text based on mode"""
         if not is_mode_enabled(mode):
@@ -314,6 +328,8 @@ class Dicton:
 
             if not llm_processor.is_available():
                 print("⚠ LLM not available (set GEMINI_API_KEY or ANTHROPIC_API_KEY)")
+                from .ui_feedback import notify
+
                 notify("⚠ LLM Not Available", "Configure LLM_PROVIDER")
                 return text  # Fallback to raw text
 
@@ -358,7 +374,7 @@ class Dicton:
         text: str,
         mode: ProcessingMode,
         replace_selection: bool,
-        context: ContextInfo | None = None,
+        context: "ContextInfo | None" = None,
     ):
         """Output the processed text using character-by-character typing.
 
@@ -388,9 +404,13 @@ class Dicton:
 
         if mode == ProcessingMode.ACT_ON_TEXT:
             print(f"✓ Replaced: {text[:50]}..." if len(text) > 50 else f"✓ {text}")
+            from .ui_feedback import notify
+
             notify("✓ Text Replaced", text[:100])
         else:
             print(f"✓ {text[:50]}..." if len(text) > 50 else f"✓ {text}")
+            from .ui_feedback import notify
+
             notify("✓ Done", text[:100])
 
     def _check_vpn_active(self) -> bool:
@@ -455,6 +475,8 @@ class Dicton:
         hotkey_display = (
             "FN" if self._use_fn_key else f"{config.HOTKEY_MODIFIER}+{config.HOTKEY_KEY}"
         )
+        from .ui_feedback import notify
+
         notify("Dicton Ready", f"Press {hotkey_display}")
 
         # Cross-platform wait loop

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -43,6 +43,34 @@ def test_cli_version_works_without_full_app_startup():
     assert result.stdout.strip() == f"Dicton v{dicton.__version__}"
 
 
+def test_cli_config_ui_works_without_full_app_startup(monkeypatch):
+    import importlib
+    import types
+
+    cli = importlib.import_module("dicton.__main__")
+    calls: list[int] = []
+    real_import = __import__
+
+    def fake_run_config_server(*, port: int) -> None:
+        calls.append(port)
+
+    fake_module = types.SimpleNamespace(run_config_server=fake_run_config_server)
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"dicton.config_server", "config_server"}:
+            return fake_module
+        if name in {"dicton.main", "main"}:
+            raise AssertionError("config-ui should not import dicton.main")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+    monkeypatch.setattr(sys, "argv", ["dicton", "--config-ui", "--config-port", "9999"])
+
+    cli.main()
+
+    assert calls == [9999]
+
+
 @pytest.mark.parametrize(
     ("relative_path", "forbidden", "required"),
     [
@@ -97,6 +125,7 @@ def test_windows_packaging_files_exist():
     assert "__file__" not in spec
     assert "SPECPATH" in spec
     assert 'project_root / "packaging" / "windows" / "pyinstaller_entry.py"' in spec
+    assert 'collect_submodules("pynput")' in spec
 
 
 def test_windows_package_job_present():
@@ -112,6 +141,8 @@ def test_linux_packaging_files_exist():
     assert (ROOT / "docs" / "linux-packaging.md").exists()
     spec = (ROOT / "packaging" / "linux" / "dicton.spec").read_text(encoding="utf-8")
     assert 'project_root / "packaging" / "windows" / "pyinstaller_entry.py"' in spec
+    assert 'collect_submodules("pynput")' in spec
+    assert 'collect_submodules("Xlib")' in spec
 
 
 def test_linux_package_job_present():


### PR DESCRIPTION
## Summary
- Add a lightweight CLI path for `--config-ui` in `dicton.__main__` so config UI can launch without importing the full app stack.
- Keep startup surface lean by deferring several heavy imports in `main.py` to runtime paths.
- Update PyInstaller specs to collect missing hidden imports (`pynput` on Windows/Linux, plus `Xlib` on Linux).
- Improve README release link formatting.
- Extend packaging-surface tests to verify `--config-ui` behavior and hidden import coverage in spec files.

## Testing
- Added `test_cli_config_ui_works_without_full_app_startup` to confirm `--config-ui` runs config server and does not import `dicton.main`.
- Verified packaging tests assert hidden import collection for:
- `collect_submodules("pynput")` in Windows/Linux specs.
- `collect_submodules("Xlib")` in Linux spec.
- Not run: full end-to-end PyInstaller build on Linux/Windows in this PR context.