### PR TITLE
Narrow CI triggers and remove package build jobs from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+  schedule:
+    - cron: "0 8 * * 1"
 
 jobs:
   lint:
@@ -77,6 +87,7 @@ jobs:
 
   smoke:
     name: Smoke (${{ matrix.os }})
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -120,65 +131,3 @@ jobs:
         run: |
           python -c "import dicton; print(dicton.__version__)"
           python -m dicton --version
-
-  windows-package:
-    name: Windows Package
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install package dependencies
-        shell: bash
-        run: pip install -e ".[windows,context-windows,notifications,llm,configui,mistral,packaging]"
-
-      - name: Build Windows bundle
-        shell: powershell
-        run: .\scripts\build-windows.ps1
-
-      - name: Smoke packaged executable
-        shell: powershell
-        run: .\dist\dicton\dicton.exe --version
-
-      - name: Upload Windows bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: dicton-windows-x64
-          path: dist/dicton-windows-x64.zip
-
-  linux-package:
-    name: Linux Package
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y portaudio19-dev libportaudio2 xdotool xclip libnotify-bin
-
-      - name: Install package dependencies
-        run: pip install -e ".[linux,packaging]"
-
-      - name: Build Linux package assets
-        run: ./scripts/build-linux-package.sh
-
-      - name: Smoke packaged executable
-        run: ./dist/dicton/dicton --version
-
-      - name: Upload Linux bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: dicton-linux-x64
-          path: |
-            dist/dicton-linux-x64.tar.gz
-            dist/dicton_*_amd64.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,42 @@ jobs:
         run: ./scripts/check.sh lint
 
   test:
-    name: Test (Python ${{ matrix.python-version }})
+    name: Test (Python 3.12)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests with coverage
+        run: ./scripts/check.sh test --cov=dicton --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+
+  test-compatibility:
+    name: Test Compatibility (Python ${{ matrix.python-version }})
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -58,15 +88,8 @@ jobs:
       - name: Install package with dev dependencies
         run: pip install -e ".[dev]"
 
-      - name: Run tests with coverage
-        run: ./scripts/check.sh test --cov=dicton --cov-report=xml --cov-report=term
-
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: false
+      - name: Run tests
+        run: ./scripts/check.sh test
 
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_call:
     inputs:
       ref:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0]
+
+### Changed
+
+- Bumped the release line to `1.2.0`.
+
 ## [1.1.2]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Download the latest release here:
 Download the `.deb` file from the latest release, then install it with:
 
 ```bash
-sudo apt install ./dicton_1.1.2_amd64.deb
+sudo apt install ./dicton_1.2.0_amd64.deb
 ```
 
 If your system prefers `dpkg`:
 
 ```bash
-sudo dpkg -i dicton_1.1.2_amd64.deb
+sudo dpkg -i dicton_1.2.0_amd64.deb
 sudo apt-get install -f
 ```
 

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -114,6 +114,10 @@ def test_check_script_covers_ci_targets():
     assert '"docs/**"' in workflow
     assert '"LICENSE"' in workflow
     assert 'cron: "0 8 * * 1"' in workflow
+    assert "name: Test (Python 3.12)" in workflow
+    assert "name: Test Compatibility (Python ${{ matrix.python-version }})" in workflow
+    assert "if: github.event_name == 'schedule'" in workflow
+    assert 'python-version: ["3.10", "3.11"]' in workflow
 
 
 def test_windows_packaging_files_exist():

--- a/tests/test_packaging_surface.py
+++ b/tests/test_packaging_surface.py
@@ -104,16 +104,16 @@ def test_update_checker_points_to_canonical_repo():
 
 def test_check_script_covers_ci_targets():
     content = (ROOT / "scripts" / "check.sh").read_text(encoding="utf-8")
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     assert "lint|test|build|all" in content
-    assert "./scripts/check.sh lint" in (ROOT / ".github" / "workflows" / "ci.yml").read_text(
-        encoding="utf-8"
-    )
-    assert "./scripts/check.sh test" in (ROOT / ".github" / "workflows" / "ci.yml").read_text(
-        encoding="utf-8"
-    )
-    assert "./scripts/check.sh build" in (ROOT / ".github" / "workflows" / "ci.yml").read_text(
-        encoding="utf-8"
-    )
+    assert "./scripts/check.sh lint" in workflow
+    assert "./scripts/check.sh test" in workflow
+    assert "./scripts/check.sh build" in workflow
+    assert "paths-ignore:" in workflow
+    assert '"**/*.md"' in workflow
+    assert '"docs/**"' in workflow
+    assert '"LICENSE"' in workflow
+    assert 'cron: "0 8 * * 1"' in workflow
 
 
 def test_windows_packaging_files_exist():
@@ -128,11 +128,12 @@ def test_windows_packaging_files_exist():
     assert 'collect_submodules("pynput")' in spec
 
 
-def test_windows_package_job_present():
+def test_smoke_job_is_pr_or_schedule_only():
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    assert "windows-package:" in workflow
-    assert r".\scripts\build-windows.ps1" in workflow
-    assert "dicton-windows-x64.zip" in workflow
+    assert "smoke:" in workflow
+    assert "if: github.event_name == 'pull_request' || github.event_name == 'schedule'" in workflow
+    assert "windows-latest" in workflow
+    assert "macos-latest" in workflow
 
 
 def test_linux_packaging_files_exist():
@@ -145,18 +146,17 @@ def test_linux_packaging_files_exist():
     assert 'collect_submodules("Xlib")' in spec
 
 
-def test_linux_package_job_present():
+def test_ci_does_not_build_release_packages():
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    assert "linux-package:" in workflow
-    assert "./scripts/build-linux-package.sh" in workflow
-    assert "dicton-linux-x64.tar.gz" in workflow
-    assert "dicton_*_amd64.deb" in workflow
+    assert "windows-package:" not in workflow
+    assert "linux-package:" not in workflow
+    assert "./scripts/build-linux-package.sh" not in workflow
+    assert r".\scripts\build-windows.ps1" not in workflow
 
 
 def test_release_workflow_present():
     workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
-    assert "tags:" in workflow
-    assert "v*" in workflow
+    assert "push:" not in workflow
     assert "workflow_call:" in workflow
     assert "workflow_dispatch:" in workflow
     assert "softprops/action-gh-release" in workflow


### PR DESCRIPTION
## Summary
- Scope CI `push` and `pull_request` runs with `paths-ignore` for docs/license-only changes.
- Add a weekly scheduled CI run (`cron: "0 8 * * 1"`).
- Restrict `smoke` job execution to pull requests and scheduled runs.
- Remove `windows-package` and `linux-package` jobs from `.github/workflows/ci.yml`.
- Update `release.yml` to stop tag-push triggering and keep `workflow_call`/`workflow_dispatch` entry points.
- Adjust packaging surface tests to validate new CI trigger behavior and assert package jobs are no longer in CI.

## Testing
- Not run (content based on provided diff/commit details).
- Verified in diff that CI includes `paths-ignore` for `**/*.md`, `docs/**`, and `LICENSE`.
- Verified in diff that CI includes scheduled run `cron: "0 8 * * 1"`.
- Verified in diff that smoke job has event guard for `pull_request` and `schedule`.
- Verified in diff that Windows/Linux package jobs were removed from CI.
- Verified in diff that release workflow no longer has `push.tags` trigger and retains `workflow_call`/`workflow_dispatch`.