### PR TITLE
feat: chunked STT pipeline, system tray, and visualizer fixes

### DIFF
--- a/packaging/linux/dicton.spec
+++ b/packaging/linux/dicton.spec
@@ -34,14 +34,37 @@ hiddenimports = [
 hiddenimports += collect_submodules("pynput")
 hiddenimports += collect_submodules("Xlib")
 
-# Collect GTK/gi typelibs for the system tray
+# Collect GTK/gi typelibs for the system tray.
+# PyGObject (gi) is a system apt package in /usr/lib/python3/dist-packages/,
+# not installable via pip.  We must add it to pathex so PyInstaller can find it.
+import subprocess
+import sys
+
 binaries = []
+_system_sp = None
+try:
+    _system_sp = subprocess.check_output(
+        [sys.executable, "-c",
+         "import sysconfig; print(sysconfig.get_path('platlib', 'posix_prefix'))"],
+        text=True,
+    ).strip()
+except Exception:
+    _system_sp = "/usr/lib/python3/dist-packages"
+
+_extra_paths = [p for p in [_system_sp, "/usr/lib/python3/dist-packages"] if Path(p).is_dir()]
+
+# Temporarily add system paths so GiModuleInfo can introspect
+for p in _extra_paths:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
 try:
     from PyInstaller.utils.hooks.gi import GiModuleInfo
 
     for gi_module, gi_version in [
         ("Gtk", "3.0"),
         ("Gdk", "3.0"),
+        ("GdkPixbuf", "2.0"),
         ("AyatanaAppIndicator3", "0.1"),
     ]:
         info = GiModuleInfo(gi_module, gi_version)
@@ -53,10 +76,17 @@ try:
 except Exception:
     pass  # gi not available at build time — tray will degrade gracefully
 
+# Also collect the gi package itself and cairo bindings
+try:
+    hiddenimports += collect_submodules("gi")
+    hiddenimports += collect_submodules("cairo")
+except Exception:
+    pass
+
 
 a = Analysis(
     [str(project_root / "packaging" / "windows" / "pyinstaller_entry.py")],
-    pathex=[str(project_root / "src")],
+    pathex=[str(project_root / "src")] + _extra_paths,
     binaries=binaries,
     datas=datas,
     hiddenimports=hiddenimports,

--- a/packaging/linux/dicton.spec
+++ b/packaging/linux/dicton.spec
@@ -25,18 +25,39 @@ hiddenimports = [
     "dicton.config_server",
     "dicton.context_detector_wayland",
     "dicton.context_detector_x11",
+    "dicton.log_setup",
     "dicton.main",
     "dicton.stt_elevenlabs",
     "dicton.stt_mistral",
+    "dicton.tray",
 ]
 hiddenimports += collect_submodules("pynput")
 hiddenimports += collect_submodules("Xlib")
+
+# Collect GTK/gi typelibs for the system tray
+binaries = []
+try:
+    from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+    for gi_module, gi_version in [
+        ("Gtk", "3.0"),
+        ("Gdk", "3.0"),
+        ("AyatanaAppIndicator3", "0.1"),
+    ]:
+        info = GiModuleInfo(gi_module, gi_version)
+        if info.available:
+            gi_binaries, gi_datas, gi_imports = info.collect_typelib_data()
+            binaries += gi_binaries
+            datas += gi_datas
+            hiddenimports += gi_imports
+except Exception:
+    pass  # gi not available at build time — tray will degrade gracefully
 
 
 a = Analysis(
     [str(project_root / "packaging" / "windows" / "pyinstaller_entry.py")],
     pathex=[str(project_root / "src")],
-    binaries=[],
+    binaries=binaries,
     datas=datas,
     hiddenimports=hiddenimports,
     hookspath=[],

--- a/scripts/build-linux-package.sh
+++ b/scripts/build-linux-package.sh
@@ -52,7 +52,7 @@ Section: utils
 Priority: optional
 Architecture: amd64
 Maintainer: asi0 flammeus <asi0@crqpt.com>
-Depends: libportaudio2, xdotool, libnotify-bin
+Depends: libportaudio2, xdotool, libnotify-bin, gir1.2-ayatanaappindicator3-0.1
 Recommends: xclip | wl-clipboard
 Description: Voice-to-text dictation with direct transcription and translation
  Dicton is a desktop dictation tool focused on direct transcription and

--- a/scripts/prepare_local_release.sh
+++ b/scripts/prepare_local_release.sh
@@ -220,7 +220,7 @@ _header "Python distribution"
 # Read version once from source of truth
 version="$(python3 -c "
 import re; from pathlib import Path
-m = re.search(r'__version__\s*=\"([^\"]+)\"', Path('src/dicton/__init__.py').read_text())
+m = re.search(r'__version__\s*=\s*\"([^\"]+)\"', Path('src/dicton/__init__.py').read_text())
 print(m.group(1))
 ")"
 

--- a/scripts/prepare_local_release.sh
+++ b/scripts/prepare_local_release.sh
@@ -216,6 +216,17 @@ fi
 # ── 6. Python dist ─────────────────────────────────────
 CURRENT_STEP=$((CURRENT_STEP + 1))
 _header "Python distribution"
+
+# Read version once from source of truth
+version="$(python3 -c "
+import re; from pathlib import Path
+m = re.search(r'__version__\s*=\"([^\"]+)\"', Path('src/dicton/__init__.py').read_text())
+print(m.group(1))
+")"
+
+# Clean stale artifacts so glob/ls can't pick up old versions
+rm -f "${PROJECT_DIR}"/dist/dicton_*_amd64.deb "${PROJECT_DIR}/dist/dicton-linux-x64.tar.gz"
+
 _run "sdist + wheel" uv build
 
 # ── 7. Linux package ───────────────────────────────────
@@ -224,12 +235,10 @@ _header "Linux packaging"
 _run "PyInstaller bundle + .deb" ./scripts/build-linux-package.sh
 
 tar_path="${PROJECT_DIR}/dist/dicton-linux-x64.tar.gz"
-deb_path="$(ls "${PROJECT_DIR}"/dist/dicton_*_amd64.deb 2>/dev/null | head -1)"
+deb_path="${PROJECT_DIR}/dist/dicton_${version}_amd64.deb"
 
 [[ -f "$tar_path" ]] || { echo -e "  ${RED}✘${RST} Tarball not found"; exit 1; }
-[[ -n "$deb_path" && -f "$deb_path" ]] || { echo -e "  ${RED}✘${RST} .deb not found in dist/"; exit 1; }
-
-version="$(dpkg-deb --field "$deb_path" Version)"
+[[ -f "$deb_path" ]] || { echo -e "  ${RED}✘${RST} .deb not found: ${deb_path##*/}"; exit 1; }
 
 # ── 8. Validation ──────────────────────────────────────
 CURRENT_STEP=$((CURRENT_STEP + 1))

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/adapters/audio.py
+++ b/src/dicton/adapters/audio.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 
 class AudioCaptureAdapter:
-    def __init__(self, recognizer):
+    def __init__(self, recognizer, chunk_manager=None):
         self._recognizer = recognizer
+        self._chunk_manager = chunk_manager
 
     def record(self):
+        if self._chunk_manager:
+            self._chunk_manager.start_session()
+            return self._recognizer.record(on_chunk=self._chunk_manager.feed_chunk)
         return self._recognizer.record()
 
     def stop(self) -> None:
@@ -15,11 +19,17 @@ class AudioCaptureAdapter:
 
     def cancel(self) -> None:
         self._recognizer.cancel()
+        if self._chunk_manager:
+            self._chunk_manager.cancel()
 
 
 class STTAdapter:
-    def __init__(self, recognizer):
+    def __init__(self, recognizer, chunk_manager=None):
         self._recognizer = recognizer
+        self._chunk_manager = chunk_manager
 
     def transcribe(self, audio):
+        if self._chunk_manager and self._chunk_manager.has_chunks:
+            result = self._chunk_manager.finalize(audio)
+            return self._recognizer.filter_text(result) if result else None
         return self._recognizer.transcribe(audio)

--- a/src/dicton/adapters/audio.py
+++ b/src/dicton/adapters/audio.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class AudioCaptureAdapter:
     def __init__(self, recognizer, chunk_manager=None):
@@ -30,6 +34,13 @@ class STTAdapter:
 
     def transcribe(self, audio):
         if self._chunk_manager and self._chunk_manager.has_chunks:
-            result = self._chunk_manager.finalize(audio)
-            return self._recognizer.filter_text(result) if result else None
+            result = self._chunk_manager.finalize()
+            if result.is_partial:
+                logger.warning(
+                    "Partial transcription: %d/%d chunks failed",
+                    result.failed_chunks,
+                    result.total_chunks,
+                )
+            text = result.text
+            return self._recognizer.filter_text(text) if text else None
         return self._recognizer.transcribe(audio)

--- a/src/dicton/app_paths.py
+++ b/src/dicton/app_paths.py
@@ -70,5 +70,9 @@ def get_latency_log_path() -> Path:
     return get_user_data_dir() / "latency.log"
 
 
+def get_log_path() -> Path:
+    return get_user_data_dir() / "dicton.log"
+
+
 def get_update_cache_path() -> Path:
     return get_user_cache_dir() / "update_cache.json"

--- a/src/dicton/application/runtime_service.py
+++ b/src/dicton/application/runtime_service.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import signal
 import threading
+from pathlib import Path
 
 from ..config import config
 from ..platform_utils import IS_LINUX, IS_WINDOWS
@@ -12,13 +14,15 @@ from ..platform_utils import IS_LINUX, IS_WINDOWS
 class RuntimeService:
     """Own application startup, runtime wait loop, and shutdown."""
 
-    def __init__(self, session_service, keyboard, recognizer, app_config):
+    def __init__(self, session_service, keyboard, recognizer, app_config, log_path=None):
         self._session_service = session_service
         self._keyboard = keyboard
         self._recognizer = recognizer
         self._app_config = app_config
+        self._log_path: Path | None = log_path
         self._shutdown_event = threading.Event()
         self._fn_handler = None
+        self._tray = None
         self._use_fn_key = False
 
         if not self._recognizer._provider_available:
@@ -66,6 +70,7 @@ class RuntimeService:
             pass
 
         self._use_fn_key = self._init_fn_handler()
+        self._init_tray()
 
         if self._use_fn_key:
             print("Hotkey: FN key (hold=PTT, double-tap=toggle)")
@@ -108,9 +113,35 @@ class RuntimeService:
 
         self.shutdown()
 
+    def _init_tray(self) -> None:
+        try:
+            from ..tray import DictonTray
+
+            self._tray = DictonTray(
+                on_quit=self.request_shutdown,
+                on_toggle_debug=self._toggle_debug,
+                log_path=self._log_path,
+            )
+            self._session_service._controller._state.add_observer(self._tray.on_state_change)
+            self._tray.start()
+        except ImportError:
+            pass
+        except Exception:
+            logging.getLogger(__name__).debug("Tray init failed", exc_info=True)
+
+    def _toggle_debug(self) -> bool:
+        config.DEBUG = not config.DEBUG
+        level = logging.DEBUG if config.DEBUG else logging.WARNING
+        logging.getLogger().setLevel(level)
+        print(f"Debug mode: {'ON' if config.DEBUG else 'OFF'}")
+        return config.DEBUG
+
     def shutdown(self) -> None:
         print("\nShutting down...")
         self._shutdown_event.set()
+
+        if self._tray:
+            self._tray.stop()
 
         if self._fn_handler:
             self._fn_handler.stop()

--- a/src/dicton/application/runtime_service.py
+++ b/src/dicton/application/runtime_service.py
@@ -14,12 +14,15 @@ from ..platform_utils import IS_LINUX, IS_WINDOWS
 class RuntimeService:
     """Own application startup, runtime wait loop, and shutdown."""
 
-    def __init__(self, session_service, keyboard, recognizer, app_config, log_path=None):
+    def __init__(
+        self, session_service, keyboard, recognizer, app_config, log_path=None, chunk_manager=None
+    ):
         self._session_service = session_service
         self._keyboard = keyboard
         self._recognizer = recognizer
         self._app_config = app_config
         self._log_path: Path | None = log_path
+        self._chunk_manager = chunk_manager
         self._shutdown_event = threading.Event()
         self._fn_handler = None
         self._tray = None
@@ -122,7 +125,7 @@ class RuntimeService:
                 on_toggle_debug=self._toggle_debug,
                 log_path=self._log_path,
             )
-            self._session_service._controller._state.add_observer(self._tray.on_state_change)
+            self._session_service.add_state_observer(self._tray.on_state_change)
             self._tray.start()
         except ImportError:
             pass
@@ -139,6 +142,9 @@ class RuntimeService:
     def shutdown(self) -> None:
         print("\nShutting down...")
         self._shutdown_event.set()
+
+        if self._chunk_manager is not None:
+            self._chunk_manager.close()
 
         if self._tray:
             self._tray.stop()

--- a/src/dicton/application/session_service.py
+++ b/src/dicton/application/session_service.py
@@ -107,11 +107,10 @@ class SessionService:
     def _update_visualizer_color(self, mode: ProcessingMode) -> None:
         try:
             if self._visualizer is None:
-                from ..visualizer import get_visualizer
+                self._visualizer = self._load_visualizer()
 
-                self._visualizer = get_visualizer()
-
-            self._visualizer.set_colors(get_mode_color(mode))
+            if self._visualizer:
+                self._visualizer.set_colors(get_mode_color(mode))
         except Exception:
             pass
 
@@ -126,7 +125,9 @@ class SessionService:
             ProcessingMode.TRANSLATE_REFORMAT: "Translate+Reformat",
             ProcessingMode.RAW: "Raw Mode",
         }
-        viz = self._load_visualizer()
+        if self._visualizer is None:
+            self._visualizer = self._load_visualizer()
+        viz = self._visualizer
 
         try:
             selected_text = None
@@ -142,10 +143,8 @@ class SessionService:
             )
 
             def _pre_output() -> None:
-                nonlocal viz
                 if viz:
                     viz.stop()
-                    viz = None
 
             success, session = self._controller.run_session(
                 mode=mode,

--- a/src/dicton/application/session_service.py
+++ b/src/dicton/application/session_service.py
@@ -32,6 +32,10 @@ class SessionService:
         """Attach the session pipeline controller after service construction."""
         self._controller = controller
 
+    def add_state_observer(self, callback) -> None:
+        """Register an observer on the session pipeline state machine."""
+        self._controller._state.add_observer(callback)
+
     @property
     def recording(self) -> bool:
         return self._recording

--- a/src/dicton/bootstrap/container.py
+++ b/src/dicton/bootstrap/container.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from ..adapters.audio import AudioCaptureAdapter, STTAdapter
 from ..adapters.audio_session_control import AudioSessionControlAdapter
 from ..adapters.config_env import load_app_config
@@ -18,7 +20,7 @@ from ..latency_tracker import get_latency_tracker
 from ..speech_recognition_engine import SpeechRecognizer
 
 
-def build_runtime_service() -> RuntimeService:
+def build_runtime_service(log_path: Path | None = None) -> RuntimeService:
     """Build the runtime service with the current production adapters."""
     config.create_dirs()
     recognizer = SpeechRecognizer()
@@ -57,4 +59,5 @@ def build_runtime_service() -> RuntimeService:
         keyboard=keyboard,
         recognizer=recognizer,
         app_config=app_config,
+        log_path=log_path,
     )

--- a/src/dicton/bootstrap/container.py
+++ b/src/dicton/bootstrap/container.py
@@ -60,4 +60,5 @@ def build_runtime_service(log_path: Path | None = None) -> RuntimeService:
         recognizer=recognizer,
         app_config=app_config,
         log_path=log_path,
+        chunk_manager=chunk_manager,
     )

--- a/src/dicton/bootstrap/container.py
+++ b/src/dicton/bootstrap/container.py
@@ -10,6 +10,7 @@ from ..adapters.text_processing import TextOutputAdapter, TextProcessorAdapter
 from ..adapters.ui_feedback import UIFeedbackAdapter
 from ..application.runtime_service import RuntimeService
 from ..application.session_service import SessionService
+from ..chunk_manager import ChunkConfig, ChunkManager
 from ..config import config
 from ..core.controller import DictationController
 from ..keyboard_handler import KeyboardHandler
@@ -21,6 +22,13 @@ def build_runtime_service() -> RuntimeService:
     """Build the runtime service with the current production adapters."""
     config.create_dirs()
     recognizer = SpeechRecognizer()
+    chunk_manager = None
+    if config.CHUNK_ENABLED:
+        chunk_config = ChunkConfig.from_app_config(config)
+        chunk_manager = ChunkManager(
+            stt_provider=recognizer.stt_provider,
+            config=chunk_config,
+        )
     keyboard = KeyboardHandler(None)
     app_config = load_app_config()
     metrics = get_latency_tracker()
@@ -33,9 +41,9 @@ def build_runtime_service() -> RuntimeService:
     )
     session_service.bind_controller(
         DictationController(
-            audio_capture=AudioCaptureAdapter(recognizer),
+            audio_capture=AudioCaptureAdapter(recognizer, chunk_manager=chunk_manager),
             audio_control=AudioSessionControlAdapter(),
-            stt=STTAdapter(recognizer),
+            stt=STTAdapter(recognizer, chunk_manager=chunk_manager),
             text_processor=TextProcessorAdapter(session_service.process_text),
             text_output=TextOutputAdapter(session_service.output_result),
             ui=UIFeedbackAdapter(),

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -6,6 +6,7 @@ them concurrently to the STT provider. Results are concatenated in order.
 
 import io
 import logging
+import time
 import wave
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
@@ -20,10 +21,11 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class ChunkConfig:
     enabled: bool
-    threshold_s: float
+    min_chunk_s: float
+    max_chunk_s: float
+    overlap_s: float
     silence_threshold: float
     silence_window_s: float
-    lookback_s: float
     chunk_size: int
     sample_rate: int
     stt_timeout: float
@@ -32,14 +34,23 @@ class ChunkConfig:
     def from_app_config(cls, cfg) -> "ChunkConfig":
         return cls(
             enabled=cfg.CHUNK_ENABLED,
-            threshold_s=cfg.CHUNK_THRESHOLD_S,
+            min_chunk_s=cfg.CHUNK_MIN_S,
+            max_chunk_s=cfg.CHUNK_MAX_S,
+            overlap_s=cfg.CHUNK_OVERLAP_S,
             silence_threshold=cfg.CHUNK_SILENCE_THRESHOLD,
             silence_window_s=cfg.CHUNK_SILENCE_WINDOW_S,
-            lookback_s=cfg.CHUNK_LOOKBACK_S,
             chunk_size=cfg.CHUNK_SIZE,
             sample_rate=cfg.SAMPLE_RATE,
             stt_timeout=cfg.STT_TIMEOUT,
         )
+
+
+@dataclass
+class FinalizeResult:
+    text: str | None
+    total_chunks: int
+    failed_chunks: int
+    is_partial: bool  # failed_chunks > 0 and text is not None
 
 
 class ChunkManager:
@@ -49,10 +60,18 @@ class ChunkManager:
         self._stt = stt_provider
         self._config = config
         self._executor = ThreadPoolExecutor(max_workers=3)
+
+        # Precompute frame-related constants
+        self._frame_duration = config.chunk_size / config.sample_rate
+        self._frames_per_window = max(1, int(config.silence_window_s / self._frame_duration))
+        self._overlap_frames = int(config.overlap_s / self._frame_duration)
+
+        # Session state
         self._frames: list[bytes] = []
         self._chunk_boundary: int = 0
         self._futures: list[Future] = []
         self._cancelled: bool = False
+        self._silent_run: int = 0
 
     # ------------------------------------------------------------------
     # Session lifecycle
@@ -64,58 +83,50 @@ class ChunkManager:
         self._chunk_boundary = 0
         self._futures = []
         self._cancelled = False
+        self._silent_run = 0
 
     # ------------------------------------------------------------------
     # Recording feed
     # ------------------------------------------------------------------
 
     def feed_chunk(self, raw_audio: bytes) -> None:
-        """Append a raw audio frame and dispatch a chunk if threshold reached."""
+        """Append a raw audio frame and dispatch a chunk on silence or hard cut."""
         self._frames.append(raw_audio)
+
+        rms = self._compute_rms(raw_audio)
+        if rms < self._config.silence_threshold:
+            self._silent_run += 1
+        else:
+            self._silent_run = 0
+
         unchunked_frames = len(self._frames) - self._chunk_boundary
-        duration_s = unchunked_frames * self._config.chunk_size / self._config.sample_rate
-        if duration_s >= self._config.threshold_s:
-            self._dispatch_chunk()
+        duration_s = unchunked_frames * self._frame_duration
+
+        if self._silent_run >= self._frames_per_window and duration_s >= self._config.min_chunk_s:
+            # Cut at the start of the silence run
+            cut_point = len(self._frames) - self._silent_run
+            self._dispatch_chunk(cut_point, "silence")
+        elif duration_s >= self._config.max_chunk_s:
+            self._dispatch_chunk(len(self._frames), "hard")
 
     # ------------------------------------------------------------------
     # Internal chunk dispatch
     # ------------------------------------------------------------------
 
-    def _dispatch_chunk(self) -> None:
-        """Find a silence cut point and submit a transcription future."""
-        start_idx = self._chunk_boundary
-        end_idx = len(self._frames)
-        cut_point = self._find_silence_point(start_idx, end_idx)
-        if cut_point is None:
-            frames_per_threshold = int(
-                self._config.threshold_s * self._config.sample_rate / self._config.chunk_size
-            )
-            cut_point = start_idx + frames_per_threshold
+    def _dispatch_chunk(self, cut_point: int, cut_type: str) -> None:
+        """Extract frames up to cut_point and submit a transcription future."""
+        frames_slice = self._frames[self._chunk_boundary : cut_point]
+        chunk_idx = len(self._futures)
+        duration_s = len(frames_slice) * self._frame_duration
 
-        frames_slice = self._frames[start_idx:cut_point]
-        future = self._executor.submit(self._transcribe_chunk, frames_slice)
+        future = self._executor.submit(self._transcribe_chunk, frames_slice, chunk_idx)
         self._futures.append(future)
-        self._chunk_boundary = cut_point
 
-    def _find_silence_point(self, start_idx: int, end_idx: int) -> int | None:
-        """Scan backwards from end_idx for N consecutive silent frames."""
-        cfg = self._config
-        frames_per_window = int(cfg.silence_window_s / (cfg.chunk_size / cfg.sample_rate))
-        if frames_per_window < 1:
-            frames_per_window = 1
+        # Overlap: rewind boundary so next chunk re-includes trailing context
+        self._chunk_boundary = max(cut_point - self._overlap_frames, self._chunk_boundary)
+        self._silent_run = 0
 
-        # Scan backwards; need `frames_per_window` consecutive silent frames
-        silent_run = 0
-        for idx in range(end_idx - 1, start_idx - 1, -1):
-            rms = self._compute_rms(self._frames[idx])
-            if rms < cfg.silence_threshold:
-                silent_run += 1
-                if silent_run >= frames_per_window:
-                    # Return the frame index where silence begins
-                    return idx
-            else:
-                silent_run = 0
-        return None
+        logger.info("Dispatched chunk %d: %.1fs, cut=%s", chunk_idx, duration_s, cut_type)
 
     # ------------------------------------------------------------------
     # Audio helpers
@@ -126,19 +137,42 @@ class ChunkManager:
         data = np.frombuffer(raw_audio, dtype=np.int16).astype(np.float32)
         return float(np.sqrt(np.mean(data**2)) / 8000)
 
-    def _transcribe_chunk(self, frames: list[bytes]) -> str | None:
-        """Join frames, convert to WAV, transcribe, return text or None."""
+    def _transcribe_chunk(self, frames: list[bytes], chunk_idx: int) -> str | None:
+        """Join frames, convert to WAV, transcribe with retry, return text or None."""
         if self._cancelled:
             return None
         raw = b"".join(frames)
         audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
         wav_bytes = self._audio_to_wav(audio)
-        try:
-            result = self._stt.transcribe(wav_bytes)
-            return result.text if result else None
-        except Exception:
-            logger.exception("Chunk transcription failed")
-            return None
+
+        max_attempts = 2
+        for attempt in range(1, max_attempts + 1):
+            t0 = time.monotonic()
+            try:
+                result = self._stt.transcribe(wav_bytes)
+                latency = time.monotonic() - t0
+                text = result.text if result else None
+                logger.info(
+                    "Chunk %d transcribed: %.2fs latency, %d chars",
+                    chunk_idx,
+                    latency,
+                    len(text) if text else 0,
+                )
+                return text
+            except Exception:
+                latency = time.monotonic() - t0
+                logger.warning(
+                    "Chunk %d attempt %d/%d failed (%.2fs)",
+                    chunk_idx,
+                    attempt,
+                    max_attempts,
+                    latency,
+                )
+                if attempt < max_attempts:
+                    time.sleep(1)
+
+        logger.error("Chunk %d: all %d attempts exhausted", chunk_idx, max_attempts)
+        return None
 
     def _audio_to_wav(self, audio: np.ndarray) -> bytes:
         """Convert float32 audio array to 16-bit mono WAV bytes."""
@@ -169,37 +203,67 @@ class ChunkManager:
     # Finalise
     # ------------------------------------------------------------------
 
-    def finalize(self, full_audio: np.ndarray) -> str | None:  # noqa: ARG002
-        """Transcribe remaining audio, wait for all futures, return joined text."""
+    def finalize(self) -> FinalizeResult:
+        """Transcribe remaining audio, wait for all futures, return FinalizeResult."""
         if self._cancelled:
-            return None
+            return FinalizeResult(
+                text=None,
+                total_chunks=len(self._futures),
+                failed_chunks=0,
+                is_partial=False,
+            )
 
         remaining_frames = self._frames[self._chunk_boundary :]
-        remaining_duration = (
-            len(remaining_frames) * self._config.chunk_size / self._config.sample_rate
-        )
+        remaining_duration = len(remaining_frames) * self._frame_duration
 
         final_future: Future | None = None
         if remaining_frames and remaining_duration > 0.5:
-            final_future = self._executor.submit(self._transcribe_chunk, remaining_frames)
+            chunk_idx = len(self._futures)
+            final_future = self._executor.submit(
+                self._transcribe_chunk, remaining_frames, chunk_idx
+            )
 
         results: list[str] = []
+        failed_chunks = 0
+
         for f in self._futures:
             try:
                 text = f.result(timeout=self._config.stt_timeout)
                 if text:
                     results.append(text)
+                else:
+                    failed_chunks += 1
             except Exception:
                 logger.exception("Error retrieving chunk result")
+                failed_chunks += 1
 
         if final_future is not None:
             try:
                 text = final_future.result(timeout=self._config.stt_timeout)
                 if text:
                     results.append(text)
+                else:
+                    failed_chunks += 1
             except Exception:
                 logger.exception("Error retrieving final chunk result")
+                failed_chunks += 1
 
-        if not results:
-            return None
-        return " ".join(results)
+        total_chunks = len(self._futures) + (1 if final_future is not None else 0)
+        total_duration = len(self._frames) * self._frame_duration
+        joined = " ".join(results) if results else None
+
+        logger.info(
+            "Session summary: %.1fs total, %d chunks dispatched, %d ok, %d failed, %d chars",
+            total_duration,
+            total_chunks,
+            total_chunks - failed_chunks,
+            failed_chunks,
+            len(joined) if joined else 0,
+        )
+
+        return FinalizeResult(
+            text=joined,
+            total_chunks=total_chunks,
+            failed_chunks=failed_chunks,
+            is_partial=failed_chunks > 0 and joined is not None,
+        )

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -1,0 +1,205 @@
+"""ChunkManager — chunked STT pipeline for long recordings.
+
+Splits audio into overlapping chunks at silence boundaries and dispatches
+them concurrently to the STT provider. Results are concatenated in order.
+"""
+
+import io
+import logging
+import wave
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+
+import numpy as np
+
+from .stt_provider import STTProvider
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ChunkConfig:
+    enabled: bool
+    threshold_s: float
+    silence_threshold: float
+    silence_window_s: float
+    lookback_s: float
+    chunk_size: int
+    sample_rate: int
+    stt_timeout: float
+
+    @classmethod
+    def from_app_config(cls, cfg) -> "ChunkConfig":
+        return cls(
+            enabled=cfg.CHUNK_ENABLED,
+            threshold_s=cfg.CHUNK_THRESHOLD_S,
+            silence_threshold=cfg.CHUNK_SILENCE_THRESHOLD,
+            silence_window_s=cfg.CHUNK_SILENCE_WINDOW_S,
+            lookback_s=cfg.CHUNK_LOOKBACK_S,
+            chunk_size=cfg.CHUNK_SIZE,
+            sample_rate=cfg.SAMPLE_RATE,
+            stt_timeout=cfg.STT_TIMEOUT,
+        )
+
+
+class ChunkManager:
+    """Manages chunked parallel transcription for long recordings."""
+
+    def __init__(self, stt_provider: STTProvider, config: ChunkConfig) -> None:
+        self._stt = stt_provider
+        self._config = config
+        self._executor = ThreadPoolExecutor(max_workers=3)
+        self._frames: list[bytes] = []
+        self._chunk_boundary: int = 0
+        self._futures: list[Future] = []
+        self._cancelled: bool = False
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def start_session(self) -> None:
+        """Reset all session state for a new recording."""
+        self._frames = []
+        self._chunk_boundary = 0
+        self._futures = []
+        self._cancelled = False
+
+    # ------------------------------------------------------------------
+    # Recording feed
+    # ------------------------------------------------------------------
+
+    def feed_chunk(self, raw_audio: bytes) -> None:
+        """Append a raw audio frame and dispatch a chunk if threshold reached."""
+        self._frames.append(raw_audio)
+        unchunked_frames = len(self._frames) - self._chunk_boundary
+        duration_s = unchunked_frames * self._config.chunk_size / self._config.sample_rate
+        if duration_s >= self._config.threshold_s:
+            self._dispatch_chunk()
+
+    # ------------------------------------------------------------------
+    # Internal chunk dispatch
+    # ------------------------------------------------------------------
+
+    def _dispatch_chunk(self) -> None:
+        """Find a silence cut point and submit a transcription future."""
+        start_idx = self._chunk_boundary
+        end_idx = len(self._frames)
+        cut_point = self._find_silence_point(start_idx, end_idx)
+        if cut_point is None:
+            frames_per_threshold = int(
+                self._config.threshold_s * self._config.sample_rate / self._config.chunk_size
+            )
+            cut_point = start_idx + frames_per_threshold
+
+        frames_slice = self._frames[start_idx:cut_point]
+        future = self._executor.submit(self._transcribe_chunk, frames_slice)
+        self._futures.append(future)
+        self._chunk_boundary = cut_point
+
+    def _find_silence_point(self, start_idx: int, end_idx: int) -> int | None:
+        """Scan backwards from end_idx for N consecutive silent frames."""
+        cfg = self._config
+        frames_per_window = int(cfg.silence_window_s / (cfg.chunk_size / cfg.sample_rate))
+        if frames_per_window < 1:
+            frames_per_window = 1
+
+        # Scan backwards; need `frames_per_window` consecutive silent frames
+        silent_run = 0
+        for idx in range(end_idx - 1, start_idx - 1, -1):
+            rms = self._compute_rms(self._frames[idx])
+            if rms < cfg.silence_threshold:
+                silent_run += 1
+                if silent_run >= frames_per_window:
+                    # Return the frame index where silence begins
+                    return idx
+            else:
+                silent_run = 0
+        return None
+
+    # ------------------------------------------------------------------
+    # Audio helpers
+    # ------------------------------------------------------------------
+
+    def _compute_rms(self, raw_audio: bytes) -> float:
+        """Compute normalised RMS identical to the visualizer formula."""
+        data = np.frombuffer(raw_audio, dtype=np.int16).astype(np.float32)
+        return float(np.sqrt(np.mean(data**2)) / 8000)
+
+    def _transcribe_chunk(self, frames: list[bytes]) -> str | None:
+        """Join frames, convert to WAV, transcribe, return text or None."""
+        if self._cancelled:
+            return None
+        raw = b"".join(frames)
+        audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+        wav_bytes = self._audio_to_wav(audio)
+        try:
+            result = self._stt.transcribe(wav_bytes)
+            return result.text if result else None
+        except Exception:
+            logger.exception("Chunk transcription failed")
+            return None
+
+    def _audio_to_wav(self, audio: np.ndarray) -> bytes:
+        """Convert float32 audio array to 16-bit mono WAV bytes."""
+        pcm = (audio * 32767).astype(np.int16)
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(self._config.sample_rate)
+            wf.writeframes(pcm.tobytes())
+        return buf.getvalue()
+
+    # ------------------------------------------------------------------
+    # Properties / control
+    # ------------------------------------------------------------------
+
+    @property
+    def has_chunks(self) -> bool:
+        return len(self._futures) > 0
+
+    def cancel(self) -> None:
+        """Signal cancellation and attempt to cancel pending futures."""
+        self._cancelled = True
+        for f in self._futures:
+            f.cancel()
+
+    # ------------------------------------------------------------------
+    # Finalise
+    # ------------------------------------------------------------------
+
+    def finalize(self, full_audio: np.ndarray) -> str | None:  # noqa: ARG002
+        """Transcribe remaining audio, wait for all futures, return joined text."""
+        if self._cancelled:
+            return None
+
+        remaining_frames = self._frames[self._chunk_boundary :]
+        remaining_duration = (
+            len(remaining_frames) * self._config.chunk_size / self._config.sample_rate
+        )
+
+        final_future: Future | None = None
+        if remaining_frames and remaining_duration > 0.5:
+            final_future = self._executor.submit(self._transcribe_chunk, remaining_frames)
+
+        results: list[str] = []
+        for f in self._futures:
+            try:
+                text = f.result(timeout=self._config.stt_timeout)
+                if text:
+                    results.append(text)
+            except Exception:
+                logger.exception("Error retrieving chunk result")
+
+        if final_future is not None:
+            try:
+                text = final_future.result(timeout=self._config.stt_timeout)
+                if text:
+                    results.append(text)
+            except Exception:
+                logger.exception("Error retrieving final chunk result")
+
+        if not results:
+            return None
+        return " ".join(results)

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from .config import config
 from .stt_provider import STTProvider
 
 logger = logging.getLogger(__name__)
@@ -146,7 +147,7 @@ class ChunkManager:
     def _compute_rms(self, raw_audio: bytes) -> float:
         """Compute normalised RMS identical to the visualizer formula."""
         data = np.frombuffer(raw_audio, dtype=np.int16).astype(np.float32)
-        return float(np.sqrt(np.mean(data**2)) / 8000)
+        return float(np.sqrt(np.mean(data**2)) / config.RMS_NORMALIZATION)
 
     def _transcribe_chunk(self, frames: list[bytes], chunk_idx: int) -> str | None:
         """Join frames, convert to WAV, transcribe with retry, return text or None."""

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -70,6 +70,9 @@ class ChunkManager:
         self._frames: list[bytes] = []
         self._chunk_boundary: int = 0
         self._futures: list[Future] = []
+        # Not formally thread-safe (read by workers, written by main thread),
+        # but bool assignment is atomic under CPython's GIL. Acceptable as-is
+        # unless migrating to free-threaded Python — use threading.Event then.
         self._cancelled: bool = False
         self._silent_run: int = 0
 
@@ -79,6 +82,14 @@ class ChunkManager:
 
     def start_session(self) -> None:
         """Reset all session state for a new recording."""
+        # Cancel and drain any in-flight futures from a previous session
+        for f in self._futures:
+            f.cancel()
+        for f in self._futures:
+            try:
+                f.result(timeout=0.1)
+            except Exception:
+                pass
         self._frames = []
         self._chunk_boundary = 0
         self._futures = []
@@ -198,6 +209,10 @@ class ChunkManager:
         self._cancelled = True
         for f in self._futures:
             f.cancel()
+
+    def close(self) -> None:
+        """Shut down the thread pool without waiting for in-flight tasks."""
+        self._executor.shutdown(wait=False, cancel_futures=True)
 
     # ------------------------------------------------------------------
     # Finalise

--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -204,6 +204,9 @@ class Config:
     # Audio settings
     SAMPLE_RATE = 16000
     CHUNK_SIZE = 1024
+    # Normalisation divisor for RMS → 0-1 range (≈ int16 max / 4).
+    # Shared by the visualizer and chunk-manager silence detector.
+    RMS_NORMALIZATION = 8000
 
     # Chunked pipeline (long recordings)
     CHUNK_ENABLED = os.getenv("CHUNK_ENABLED", "true").lower() == "true"

--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -205,6 +205,13 @@ class Config:
     SAMPLE_RATE = 16000
     CHUNK_SIZE = 1024
 
+    # Chunked pipeline (long recordings)
+    CHUNK_ENABLED = os.getenv("CHUNK_ENABLED", "true").lower() == "true"
+    CHUNK_THRESHOLD_S = float(os.getenv("CHUNK_THRESHOLD_S", "20"))
+    CHUNK_SILENCE_THRESHOLD = float(os.getenv("CHUNK_SILENCE_THRESHOLD", "0.03"))
+    CHUNK_SILENCE_WINDOW_S = float(os.getenv("CHUNK_SILENCE_WINDOW_S", "0.3"))
+    CHUNK_LOOKBACK_S = float(os.getenv("CHUNK_LOOKBACK_S", "5"))
+
     # Audio control during recording (Linux only)
     # Mute playback while recording (pauses players, then mutes sink if needed)
     MUTE_PLAYBACK_ON_RECORDING = os.getenv("MUTE_PLAYBACK_ON_RECORDING", "true").lower() == "true"

--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -207,10 +207,11 @@ class Config:
 
     # Chunked pipeline (long recordings)
     CHUNK_ENABLED = os.getenv("CHUNK_ENABLED", "true").lower() == "true"
-    CHUNK_THRESHOLD_S = float(os.getenv("CHUNK_THRESHOLD_S", "20"))
+    CHUNK_MIN_S = float(os.getenv("CHUNK_MIN_S", "30"))
+    CHUNK_MAX_S = float(os.getenv("CHUNK_MAX_S", "120"))
+    CHUNK_OVERLAP_S = float(os.getenv("CHUNK_OVERLAP_S", "2.0"))
     CHUNK_SILENCE_THRESHOLD = float(os.getenv("CHUNK_SILENCE_THRESHOLD", "0.03"))
     CHUNK_SILENCE_WINDOW_S = float(os.getenv("CHUNK_SILENCE_WINDOW_S", "0.3"))
-    CHUNK_LOOKBACK_S = float(os.getenv("CHUNK_LOOKBACK_S", "5"))
 
     # Audio control during recording (Linux only)
     # Mute playback while recording (pauses players, then mutes sink if needed)

--- a/src/dicton/core/controller.py
+++ b/src/dicton/core/controller.py
@@ -20,7 +20,7 @@ from .ports import (
     TextProcessor,
     UIFeedback,
 )
-from .state_machine import SessionEvent, SessionStateMachine
+from .state_machine import SessionEvent, SessionState, SessionStateMachine
 
 if TYPE_CHECKING:
     from ..context_detector import ContextInfo
@@ -111,7 +111,11 @@ class DictationController:
                 self._state.transition(SessionEvent.CANCEL)
                 return False, tracker.end_session()
 
-            self._state.transition(SessionEvent.STOP)
+            # Transition to PROCESSING if not already done by stop().
+            # stop() calls transition(STOP) when triggered externally (PTT release),
+            # but for other flows the state may still be RECORDING.
+            if self._state.state == SessionState.RECORDING:
+                self._state.transition(SessionEvent.STOP)
 
             if audio is None or len(audio) == 0:
                 print("No audio captured")

--- a/src/dicton/core/state_machine.py
+++ b/src/dicton/core/state_machine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from enum import Enum, auto
 
 
@@ -52,6 +53,11 @@ _TRANSITIONS = {
 class SessionStateMachine:
     def __init__(self):
         self.state = SessionState.IDLE
+        self._observers: list[Callable[[SessionState], None]] = []
+
+    def add_observer(self, callback: Callable[[SessionState], None]) -> None:
+        """Register a callable to be notified on every state transition."""
+        self._observers.append(callback)
 
     def transition(self, event: SessionEvent) -> SessionState:
         next_state = _TRANSITIONS.get(self.state, {}).get(event, self.state)
@@ -60,4 +66,9 @@ class SessionStateMachine:
                 "Invalid state transition: %s --%s--> %s", self.state, event, next_state
             )
         self.state = next_state
+        for cb in self._observers:
+            try:
+                cb(self.state)
+            except Exception:
+                logging.getLogger(__name__).exception("State observer error")
         return self.state

--- a/src/dicton/log_setup.py
+++ b/src/dicton/log_setup.py
@@ -1,0 +1,129 @@
+"""File logging for headless operation.
+
+Dicton runs via XDG autostart with Terminal=false — all print() output goes
+to /dev/null.  This module installs a TeeWriter on stdout/stderr so every
+print() also lands in ~/.local/share/dicton/dicton.log without touching any
+call site.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .app_paths import get_log_path
+
+_MAX_LOG_BYTES = 2 * 1024 * 1024  # 2 MB
+
+
+class _TeeWriter(io.TextIOBase):
+    """Write to *both* the original stream and a log file.
+
+    When there is no TTY (headless autostart), the original stream is
+    effectively /dev/null — writes still go to the log file.
+
+    ``fileno()`` delegates to the original stream so fd-level ops like
+    ``os.dup2(devnull, 2)`` in ``suppress_stderr()`` keep working.
+    """
+
+    def __init__(self, original: io.TextIOBase, log_file: io.TextIOBase):
+        self._original = original
+        self._log_file = log_file
+
+    # -- io.TextIOBase interface ------------------------------------------
+
+    def write(self, s: str) -> int:
+        try:
+            self._original.write(s)
+        except Exception:
+            pass
+        try:
+            self._log_file.write(s)
+            self._log_file.flush()
+        except Exception:
+            pass
+        return len(s)
+
+    def flush(self) -> None:
+        try:
+            self._original.flush()
+        except Exception:
+            pass
+        try:
+            self._log_file.flush()
+        except Exception:
+            pass
+
+    def fileno(self) -> int:
+        return self._original.fileno()
+
+    @property
+    def encoding(self) -> str:  # type: ignore[override]
+        return getattr(self._original, "encoding", "utf-8")
+
+    @property
+    def errors(self) -> str | None:  # type: ignore[override]
+        return getattr(self._original, "errors", None)
+
+    def isatty(self) -> bool:
+        return self._original.isatty()
+
+    def readable(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return True
+
+
+def _rotate_log(log_path: Path) -> None:
+    """Rotate if *log_path* exceeds ``_MAX_LOG_BYTES``."""
+    try:
+        if log_path.exists() and log_path.stat().st_size > _MAX_LOG_BYTES:
+            backup = log_path.with_suffix(".log.1")
+            log_path.replace(backup)
+    except OSError:
+        pass
+
+
+def setup_logging() -> Path:
+    """Install file logging and return the log file path.
+
+    * Rotates the log if it exceeds 2 MB.
+    * Wraps stdout/stderr with :class:`_TeeWriter`.
+    * Configures :mod:`logging` so existing ``getLogger()`` calls emit to
+      the same file.
+
+    Returns the log file :class:`Path` (useful for the tray "View Log" action).
+    """
+    log_path = get_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _rotate_log(log_path)
+
+    log_file = open(log_path, "a", encoding="utf-8")  # noqa: SIM115
+
+    # Session separator
+    now = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    log_file.write(f"\n{'=' * 60}\n")
+    log_file.write(f"  Dicton session started — {now}\n")
+    log_file.write(f"{'=' * 60}\n\n")
+    log_file.flush()
+
+    sys.stdout = _TeeWriter(sys.__stdout__, log_file)  # type: ignore[assignment]
+    sys.stderr = _TeeWriter(sys.__stderr__, log_file)  # type: ignore[assignment]
+
+    # Activate the ~8 existing logging.getLogger() calls in the codebase
+    from .config import config
+
+    level = logging.DEBUG if config.DEBUG else logging.WARNING
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+        stream=sys.stderr,
+        force=True,
+    )
+
+    return log_path

--- a/src/dicton/main.py
+++ b/src/dicton/main.py
@@ -147,7 +147,11 @@ def main() -> None:
         print("⚠ Dicton is already running. Exiting.")
         return
 
-    app = build_runtime_service()
+    from .log_setup import setup_logging
+
+    log_path = setup_logging()
+
+    app = build_runtime_service(log_path=log_path)
 
     def signal_handler(sig, frame):
         app.request_shutdown()

--- a/src/dicton/speech_recognition_engine.py
+++ b/src/dicton/speech_recognition_engine.py
@@ -86,6 +86,11 @@ class SpeechRecognizer:
         """Check if any STT provider is available (legacy compatibility)."""
         return self._provider_available
 
+    @property
+    def stt_provider(self) -> STTProvider:
+        """Expose underlying STT provider for direct use (e.g., chunked pipeline)."""
+        return self._stt_provider
+
     def _find_input_device(self):
         """Find the best available input device - cross-platform."""
         self.device_sample_rate = config.SAMPLE_RATE
@@ -170,7 +175,7 @@ class SpeechRecognizer:
 
         return selected
 
-    def record(self) -> np.ndarray | None:
+    def record(self, on_chunk=None) -> np.ndarray | None:
         """Record audio until stopped, with visualizer feedback.
 
         Note: After recording stops, the visualizer switches to processing mode
@@ -206,6 +211,8 @@ class SpeechRecognizer:
                     data = stream.read(config.CHUNK_SIZE, exception_on_overflow=False)
                     frames.append(data)
                     viz.update(data)
+                    if on_chunk:
+                        on_chunk(data)
                 except Exception as e:
                     if config.DEBUG:
                         print(f"⚠ Read error: {e}")
@@ -389,6 +396,10 @@ class SpeechRecognizer:
         text = processor.process(text)
 
         return text
+
+    def filter_text(self, text: str) -> str | None:
+        """Apply noise filtering and dictionary to externally-provided text."""
+        return self._filter(text)
 
     def cleanup(self):
         """Cleanup resources."""

--- a/src/dicton/tray.py
+++ b/src/dicton/tray.py
@@ -1,0 +1,250 @@
+"""System tray icon for Dicton using AyatanaAppIndicator3.
+
+Provides a persistent tray presence with:
+- Color-coded state indicator (idle/recording/processing/error)
+- Debug mode toggle
+- Quick access to log file and settings
+- Clean quit action
+
+Gracefully degrades to a no-op if GTK/AppIndicator is not installed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .core.state_machine import SessionState
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+# Flexoki-derived icon colors per state
+_STATE_COLORS: dict[str, str] = {
+    "IDLE": "#878787",
+    "RECORDING": "#BC5215",
+    "PROCESSING": "#205EA6",
+    "OUTPUTTING": "#205EA6",
+    "ERROR": "#AF3029",
+}
+
+_STATE_LABELS: dict[str, str] = {
+    "IDLE": "Idle",
+    "RECORDING": "Recording…",
+    "PROCESSING": "Processing…",
+    "OUTPUTTING": "Outputting…",
+    "ERROR": "Error",
+}
+
+_ICON_SIZE = 24
+_icon_cache: dict[str, str] = {}
+
+
+def _generate_icon(hex_color: str) -> str:
+    """Generate a colored circle PNG via Cairo, return path. Cached per color."""
+    if hex_color in _icon_cache:
+        return _icon_cache[hex_color]
+
+    try:
+        import cairo
+    except ImportError:
+        import cairocffi as cairo  # type: ignore[no-redefine]
+
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, _ICON_SIZE, _ICON_SIZE)
+    ctx = cairo.Context(surface)
+
+    # Parse hex color
+    r = int(hex_color[1:3], 16) / 255.0
+    g = int(hex_color[3:5], 16) / 255.0
+    b = int(hex_color[5:7], 16) / 255.0
+
+    # Draw filled circle
+    ctx.arc(_ICON_SIZE / 2, _ICON_SIZE / 2, _ICON_SIZE / 2 - 1, 0, 2 * 3.14159265)
+    ctx.set_source_rgb(r, g, b)
+    ctx.fill()
+
+    # Save to temp file (stable name per color so we don't leak files)
+    color_hash = hashlib.md5(hex_color.encode()).hexdigest()[:8]  # noqa: S324
+    path = Path(tempfile.gettempdir()) / f"dicton-tray-{color_hash}.png"
+    surface.write_to_png(str(path))
+
+    _icon_cache[hex_color] = str(path)
+    return str(path)
+
+
+class DictonTray:
+    """System tray icon backed by AyatanaAppIndicator3.
+
+    All GTK interactions happen on a dedicated daemon thread.
+    State updates are marshalled via ``GLib.idle_add()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_quit: Callable[[], None],
+        on_toggle_debug: Callable[[], bool],
+        log_path: Path | None = None,
+        config_port: int = 6873,
+    ):
+        self._on_quit = on_quit
+        self._on_toggle_debug = on_toggle_debug
+        self._log_path = log_path
+        self._config_port = config_port
+        self._indicator = None
+        self._status_item = None
+        self._debug_item = None
+        self._gtk_thread: threading.Thread | None = None
+        self._started = False
+
+    # -- Public API -------------------------------------------------------
+
+    def start(self) -> None:
+        """Spin up the GTK main loop in a daemon thread."""
+        self._gtk_thread = threading.Thread(target=self._run_gtk, daemon=True, name="dicton-tray")
+        self._gtk_thread.start()
+
+    def on_state_change(self, state: SessionState) -> None:
+        """Observer callback — called from any thread on state transitions."""
+        if not self._started:
+            return
+        try:
+            from gi.repository import GLib
+
+            GLib.idle_add(self._update_state, state)
+        except Exception:
+            pass
+
+    # -- GTK thread -------------------------------------------------------
+
+    def _run_gtk(self) -> None:
+        try:
+            import gi
+
+            gi.require_version("Gtk", "3.0")
+            gi.require_version("AyatanaAppIndicator3", "0.1")
+            from gi.repository import AyatanaAppIndicator3, Gtk
+
+            icon_path = _generate_icon(_STATE_COLORS["IDLE"])
+
+            self._indicator = AyatanaAppIndicator3.Indicator.new(
+                "dicton",
+                icon_path,
+                AyatanaAppIndicator3.IndicatorCategory.APPLICATION_STATUS,
+            )
+            self._indicator.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)
+            self._indicator.set_menu(self._build_menu(Gtk))
+
+            self._started = True
+            logger.debug("System tray started")
+            Gtk.main()
+        except Exception:
+            logger.debug("System tray unavailable", exc_info=True)
+
+    def _build_menu(self, Gtk):  # noqa: N803
+        menu = Gtk.Menu()
+
+        # Status label (not clickable)
+        self._status_item = Gtk.MenuItem(label="Dicton — Idle")
+        self._status_item.set_sensitive(False)
+        menu.append(self._status_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        # Debug toggle
+        from .config import config
+
+        debug_label = f"Debug mode: {'ON' if config.DEBUG else 'OFF'}"
+        self._debug_item = Gtk.MenuItem(label=debug_label)
+        self._debug_item.connect("activate", self._on_debug_clicked)
+        menu.append(self._debug_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        # Open Settings
+        settings_item = Gtk.MenuItem(label="Open Settings")
+        settings_item.connect("activate", self._on_settings_clicked)
+        menu.append(settings_item)
+
+        # View Log
+        if self._log_path:
+            log_item = Gtk.MenuItem(label="View Log")
+            log_item.connect("activate", self._on_view_log_clicked)
+            menu.append(log_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        # Quit
+        quit_item = Gtk.MenuItem(label="Quit")
+        quit_item.connect("activate", self._on_quit_clicked)
+        menu.append(quit_item)
+
+        menu.show_all()
+        return menu
+
+    # -- State updates (GTK thread via idle_add) --------------------------
+
+    def _update_state(self, state: SessionState) -> bool:
+        """Update icon and label. Returns False to remove from idle queue."""
+        name = state.name
+        color = _STATE_COLORS.get(name, _STATE_COLORS["IDLE"])
+        label = _STATE_LABELS.get(name, name)
+
+        if self._indicator:
+            icon_path = _generate_icon(color)
+            self._indicator.set_icon_full(icon_path, f"Dicton — {label}")
+
+        if self._status_item:
+            self._status_item.set_label(f"Dicton — {label}")
+
+        return False  # remove from idle queue
+
+    # -- Menu callbacks (GTK thread) --------------------------------------
+
+    def _on_debug_clicked(self, _widget) -> None:
+        is_debug = self._on_toggle_debug()
+        if self._debug_item:
+            self._debug_item.set_label(f"Debug mode: {'ON' if is_debug else 'OFF'}")
+
+    def _on_settings_clicked(self, _widget) -> None:
+        try:
+            subprocess.Popen(  # noqa: S603
+                ["dicton", "--config-ui", "--config-port", str(self._config_port)],
+                start_new_session=True,
+            )
+        except FileNotFoundError:
+            logger.warning("Could not launch dicton --config-ui")
+
+    def _on_view_log_clicked(self, _widget) -> None:
+        if self._log_path and self._log_path.exists():
+            try:
+                subprocess.Popen(["xdg-open", str(self._log_path)], start_new_session=True)  # noqa: S603
+            except FileNotFoundError:
+                logger.warning("xdg-open not found")
+
+    def _on_quit_clicked(self, _widget) -> None:
+        self._on_quit()
+        try:
+            from gi.repository import Gtk
+
+            Gtk.main_quit()
+        except Exception:
+            pass
+
+    def stop(self) -> None:
+        """Shut down the GTK main loop."""
+        if not self._started:
+            return
+        try:
+            from gi.repository import GLib, Gtk
+
+            GLib.idle_add(Gtk.main_quit)
+        except Exception:
+            pass

--- a/src/dicton/tray.py
+++ b/src/dicton/tray.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 # Flexoki-derived icon colors per state
 _STATE_COLORS: dict[str, str] = {
-    "IDLE": "#878787",
+    "IDLE": "#100F0F",
     "RECORDING": "#BC5215",
     "PROCESSING": "#205EA6",
     "OUTPUTTING": "#205EA6",

--- a/src/dicton/visualizer.py
+++ b/src/dicton/visualizer.py
@@ -212,6 +212,10 @@ class Visualizer:
             screen = pygame.display.set_mode((SIZE, SIZE), pygame.NOFRAME)
             pygame.display.set_caption("Dicton")
 
+            # Set window type hint for tiling WMs (i3, sway, etc.)
+            if IS_LINUX and IS_X11:
+                self._set_x11_window_type(pygame)
+
             # Enable transparency based on platform
             if IS_WINDOWS and self.transparent:
                 self._setup_windows_transparency(pygame)
@@ -236,6 +240,33 @@ class Visualizer:
         except Exception as e:
             print(f"Visualizer error: {e}")
             self._ready.set()
+
+    def _set_x11_window_type(self, pygame):
+        """Set X11 window type to NOTIFICATION so tiling WMs float it."""
+        try:
+            from Xlib import display
+
+            wm_info = pygame.display.get_wm_info()
+            window_id = wm_info.get("window")
+            if not window_id:
+                return
+
+            d = display.Display()
+            window = d.create_resource_object("window", window_id)
+
+            # Set _NET_WM_WINDOW_TYPE to _NET_WM_WINDOW_TYPE_NOTIFICATION
+            wm_type = d.intern_atom("_NET_WM_WINDOW_TYPE")
+            wm_type_notification = d.intern_atom("_NET_WM_WINDOW_TYPE_NOTIFICATION")
+            window.change_property(wm_type, d.intern_atom("ATOM"), 32, [wm_type_notification])
+            d.sync()
+
+            if config.DEBUG:
+                print("✓ X11 window type set to NOTIFICATION (floating in tiling WMs)")
+        except ImportError:
+            pass
+        except Exception as e:
+            if config.DEBUG:
+                print(f"⚠ Could not set X11 window type: {e}")
 
     def _setup_windows_transparency(self, pygame):
         """Set up transparent window on Windows using layered window API"""

--- a/src/dicton/visualizer.py
+++ b/src/dicton/visualizer.py
@@ -242,7 +242,7 @@ class Visualizer:
             self._ready.set()
 
     def _set_x11_window_type(self, pygame):
-        """Set X11 window type to NOTIFICATION so tiling WMs float it."""
+        """Set X11 window type to UTILITY so tiling WMs (i3) auto-float it."""
         try:
             from Xlib import display
 
@@ -254,14 +254,14 @@ class Visualizer:
             d = display.Display()
             window = d.create_resource_object("window", window_id)
 
-            # Set _NET_WM_WINDOW_TYPE to _NET_WM_WINDOW_TYPE_NOTIFICATION
+            # UTILITY is in i3's auto-float list (NOTIFICATION is not)
             wm_type = d.intern_atom("_NET_WM_WINDOW_TYPE")
-            wm_type_notification = d.intern_atom("_NET_WM_WINDOW_TYPE_NOTIFICATION")
-            window.change_property(wm_type, d.intern_atom("ATOM"), 32, [wm_type_notification])
+            wm_utility = d.intern_atom("_NET_WM_WINDOW_TYPE_UTILITY")
+            window.change_property(wm_type, d.intern_atom("ATOM"), 32, [wm_utility])
             d.sync()
 
             if config.DEBUG:
-                print("✓ X11 window type set to NOTIFICATION (floating in tiling WMs)")
+                print("✓ X11 window type set to UTILITY (floating in tiling WMs)")
         except ImportError:
             pass
         except Exception as e:

--- a/src/dicton/visualizer.py
+++ b/src/dicton/visualizer.py
@@ -130,7 +130,7 @@ class Visualizer:
                 return
 
             # Calculate raw RMS (before gain)
-            raw_rms = np.sqrt(np.mean(data.astype(np.float32) ** 2)) / 8000
+            raw_rms = np.sqrt(np.mean(data.astype(np.float32) ** 2)) / config.RMS_NORMALIZATION
 
             # Adaptive gain adjustment based on peak levels
             with self.lock:

--- a/src/dicton/visualizer_gtk.py
+++ b/src/dicton/visualizer_gtk.py
@@ -53,8 +53,6 @@ class TransparentVisualizerWindow(Gtk.Window):
         self.set_keep_above(True)  # Always on top
         self.set_skip_taskbar_hint(True)  # Don't show in taskbar
         self.set_skip_pager_hint(True)  # Don't show in pager
-        self.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)  # Float in tiling WMs
-
         # Enable ARGB visual for true transparency
         screen = self.get_screen()
         visual = screen.get_rgba_visual()
@@ -373,6 +371,7 @@ class Visualizer:
         self.window = None
         self.processing = False  # Processing mode (pulsing loader animation)
         self._owns_gtk_loop = False
+        self._pending_color: str | None = None  # Color to apply when window is created
 
     def set_colors(self, color_name: str):
         """Dynamically switch ring color by Flexoki color name."""
@@ -381,6 +380,9 @@ class Visualizer:
         color_name = color_name.lower()
         if color_name not in FLEXOKI_COLORS:
             color_name = "orange"
+
+        # Store for later if window doesn't exist yet
+        self._pending_color = color_name
 
         colors = FLEXOKI_COLORS[color_name]
         if self.window:
@@ -496,8 +498,18 @@ class Visualizer:
             pos_x, pos_y = config.get_animation_position(screen_w, screen_h, SIZE)
 
             self.window = TransparentVisualizerWindow()
+
+            # Apply pending color if set_colors() was called before window creation
+            if self._pending_color:
+                self.set_colors(self._pending_color)
+
             self.window.move(pos_x, pos_y)
             self.window.show_all()
+
+            # Set X11 window type directly for tiling WM compatibility (i3, sway).
+            # GTK type hints don't always translate to the X11 property.
+            self._set_x11_window_type()
+
             self.window.start_animation()
         except Exception as e:
             print(f"GTK Visualizer window creation error: {e}")
@@ -508,6 +520,28 @@ class Visualizer:
         finally:
             self._ready.set()
         return False  # run once
+
+    def _set_x11_window_type(self):
+        """Set _NET_WM_WINDOW_TYPE via Xlib so tiling WMs float this window."""
+        try:
+            from Xlib import display as xdisplay
+
+            gdk_window = self.window.get_window()
+            if gdk_window is None:
+                return
+            xid = gdk_window.get_xid()
+
+            d = xdisplay.Display()
+            window = d.create_resource_object("window", xid)
+            wm_type = d.intern_atom("_NET_WM_WINDOW_TYPE")
+            wm_notification = d.intern_atom("_NET_WM_WINDOW_TYPE_NOTIFICATION")
+            window.change_property(wm_type, d.intern_atom("ATOM"), 32, [wm_notification])
+            d.sync()
+        except ImportError:
+            pass
+        except Exception as e:
+            if config.DEBUG:
+                print(f"⚠ Could not set X11 window type: {e}")
 
 
 # Singleton instance

--- a/src/dicton/visualizer_gtk.py
+++ b/src/dicton/visualizer_gtk.py
@@ -313,7 +313,7 @@ class TransparentVisualizerWindow(Gtk.Window):
                 return
 
             # Calculate raw RMS
-            raw_rms = np.sqrt(np.mean(data.astype(np.float32) ** 2)) / 8000
+            raw_rms = np.sqrt(np.mean(data.astype(np.float32) ** 2)) / config.RMS_NORMALIZATION
 
             with self.lock:
                 # Adaptive gain control

--- a/src/dicton/visualizer_gtk.py
+++ b/src/dicton/visualizer_gtk.py
@@ -49,10 +49,12 @@ class TransparentVisualizerWindow(Gtk.Window):
 
         # Window setup
         self.set_size_request(SIZE, SIZE)
+        self.set_resizable(False)  # Fixed size — also triggers i3 auto-float (min==max)
         self.set_decorated(False)  # No window decorations
         self.set_keep_above(True)  # Always on top
         self.set_skip_taskbar_hint(True)  # Don't show in taskbar
         self.set_skip_pager_hint(True)  # Don't show in pager
+        self.set_type_hint(Gdk.WindowTypeHint.UTILITY)  # Float in tiling WMs
         # Enable ARGB visual for true transparency
         screen = self.get_screen()
         visual = screen.get_rgba_visual()
@@ -504,11 +506,13 @@ class Visualizer:
                 self.set_colors(self._pending_color)
 
             self.window.move(pos_x, pos_y)
-            self.window.show_all()
 
-            # Set X11 window type directly for tiling WM compatibility (i3, sway).
-            # GTK type hints don't always translate to the X11 property.
+            # realize() creates the underlying X11 window without mapping it,
+            # so we can set _NET_WM_WINDOW_TYPE BEFORE i3 sees the MapRequest.
+            self.window.realize()
             self._set_x11_window_type()
+
+            self.window.show_all()
 
             self.window.start_animation()
         except Exception as e:
@@ -522,7 +526,12 @@ class Visualizer:
         return False  # run once
 
     def _set_x11_window_type(self):
-        """Set _NET_WM_WINDOW_TYPE via Xlib so tiling WMs float this window."""
+        """Set _NET_WM_WINDOW_TYPE via Xlib so tiling WMs float this window.
+
+        Must be called after realize() but before show_all() so i3 sees the
+        property on the initial MapRequest. Uses UTILITY which i3 auto-floats
+        (NOTIFICATION is not in i3's float list).
+        """
         try:
             from Xlib import display as xdisplay
 
@@ -534,8 +543,8 @@ class Visualizer:
             d = xdisplay.Display()
             window = d.create_resource_object("window", xid)
             wm_type = d.intern_atom("_NET_WM_WINDOW_TYPE")
-            wm_notification = d.intern_atom("_NET_WM_WINDOW_TYPE_NOTIFICATION")
-            window.change_property(wm_type, d.intern_atom("ATOM"), 32, [wm_notification])
+            wm_utility = d.intern_atom("_NET_WM_WINDOW_TYPE_UTILITY")
+            window.change_property(wm_type, d.intern_atom("ATOM"), 32, [wm_utility])
             d.sync()
         except ImportError:
             pass

--- a/src/dicton/visualizer_gtk.py
+++ b/src/dicton/visualizer_gtk.py
@@ -53,6 +53,7 @@ class TransparentVisualizerWindow(Gtk.Window):
         self.set_keep_above(True)  # Always on top
         self.set_skip_taskbar_hint(True)  # Don't show in taskbar
         self.set_skip_pager_hint(True)  # Don't show in pager
+        self.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)  # Float in tiling WMs
 
         # Enable ARGB visual for true transparency
         screen = self.get_screen()
@@ -371,6 +372,23 @@ class Visualizer:
         self._ready = threading.Event()
         self.window = None
         self.processing = False  # Processing mode (pulsing loader animation)
+        self._owns_gtk_loop = False
+
+    def set_colors(self, color_name: str):
+        """Dynamically switch ring color by Flexoki color name."""
+        from .config import FLEXOKI_COLORS
+
+        color_name = color_name.lower()
+        if color_name not in FLEXOKI_COLORS:
+            color_name = "orange"
+
+        colors = FLEXOKI_COLORS[color_name]
+        if self.window:
+            with self.window.lock:
+                self.window.color_main = tuple(c / 255.0 for c in colors["main"])
+                self.window.color_mid = tuple(c / 255.0 for c in colors["mid"])
+                self.window.color_dim = tuple(c / 255.0 for c in colors["dim"])
+                self.window.color_glow = tuple(c / 255.0 for c in colors["glow"])
 
     def start(self):
         """Start the visualizer in a separate thread."""
@@ -404,11 +422,12 @@ class Visualizer:
         """
         self.processing = True
         if self.window:
-            self.window.processing = True
-            # Reset audio levels for clean pulsing animation
-            self.window.levels = [0.0] * WAVE_POINTS
-            self.window.smooth_levels = [0.0] * WAVE_POINTS
-            self.window.global_level = 0.0
+            with self.window.lock:
+                self.window.processing = True
+                # Reset audio levels for clean pulsing animation (must stay numpy arrays)
+                self.window.levels = np.zeros(WAVE_POINTS)
+                self.window.smooth_levels = np.zeros(WAVE_POINTS)
+                self.window.global_level = 0.0
 
     def _destroy_window(self):
         """Destroy window from GTK thread."""
@@ -416,7 +435,8 @@ class Visualizer:
             self.window.stop_animation()
             self.window.destroy()
             self.window = None
-        Gtk.main_quit()
+        if self._owns_gtk_loop:
+            Gtk.main_quit()
         return False
 
     def update(self, audio_chunk: bytes):
@@ -426,31 +446,35 @@ class Visualizer:
             GLib.idle_add(self.window.update_audio, audio_chunk)
 
     def _run(self):
-        """Run the GTK main loop."""
+        """Run the GTK visualizer.
+
+        If a GTK main loop is already running (e.g. from the system tray),
+        we schedule window creation on that loop via GLib.idle_add().
+        Otherwise we start our own loop.
+        """
         try:
-            # Initialize GTK (thread-safe)
-            GLib.threads_init()
-            Gdk.threads_init()
+            # Schedule window creation on the GTK main context
+            GLib.idle_add(self._create_window)
 
-            # Get screen dimensions for positioning
-            display = Gdk.Display.get_default()
-            monitor = display.get_primary_monitor()
-            geometry = monitor.get_geometry()
-            screen_w, screen_h = geometry.width, geometry.height
+            # Check if a GTK main loop is already running (e.g. from the tray).
+            # Gtk.main_level() is per-thread, so we probe the default context:
+            # if we can acquire it, nobody else is running a loop.
+            ctx = GLib.MainContext.default()
+            owns = ctx.acquire()
+            if owns:
+                ctx.release()
+                # No existing loop — start our own
+                self._owns_gtk_loop = True
+                Gtk.main()
+            else:
+                # Another thread (tray) is running Gtk.main(); piggyback on it.
+                self._owns_gtk_loop = False
+                self._ready.wait(timeout=3.0)  # wait for idle_add to fire
+                # Keep thread alive until stop() is called
+                while self.running:
+                    import time
 
-            # Calculate position
-            pos_x, pos_y = config.get_animation_position(screen_w, screen_h, SIZE)
-
-            # Create window
-            self.window = TransparentVisualizerWindow()
-            self.window.move(pos_x, pos_y)
-            self.window.show_all()
-            self.window.start_animation()
-
-            self._ready.set()
-
-            # Run GTK main loop
-            Gtk.main()
+                    time.sleep(0.1)
 
         except Exception as e:
             print(f"GTK Visualizer error: {e}")
@@ -460,6 +484,30 @@ class Visualizer:
                 traceback.print_exc()
         finally:
             self._ready.set()
+
+    def _create_window(self):
+        """Create the visualizer window (called on GTK thread via idle_add)."""
+        try:
+            display = Gdk.Display.get_default()
+            monitor = display.get_primary_monitor()
+            geometry = monitor.get_geometry()
+            screen_w, screen_h = geometry.width, geometry.height
+
+            pos_x, pos_y = config.get_animation_position(screen_w, screen_h, SIZE)
+
+            self.window = TransparentVisualizerWindow()
+            self.window.move(pos_x, pos_y)
+            self.window.show_all()
+            self.window.start_animation()
+        except Exception as e:
+            print(f"GTK Visualizer window creation error: {e}")
+            if config.DEBUG:
+                import traceback
+
+                traceback.print_exc()
+        finally:
+            self._ready.set()
+        return False  # run once
 
 
 # Singleton instance

--- a/src/dicton/visualizer_vispy.py
+++ b/src/dicton/visualizer_vispy.py
@@ -642,7 +642,7 @@ class VisPyVisualizerCanvas(app.Canvas):
                 return
 
             # Calculate RMS for global level
-            rms = np.sqrt(np.mean(data.astype(np.float32) ** 2)) / 8000
+            rms = np.sqrt(np.mean(data.astype(np.float32) ** 2)) / config.RMS_NORMALIZATION
             rms = min(1.0, rms * 1.8)
 
             # FFT analysis

--- a/tests/test_chunk_manager.py
+++ b/tests/test_chunk_manager.py
@@ -2,12 +2,12 @@
 
 import os
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
-from dicton.chunk_manager import ChunkConfig, ChunkManager
+from dicton.chunk_manager import ChunkConfig, ChunkManager, FinalizeResult
 from dicton.stt_provider import TranscriptionResult
 
 # ---------------------------------------------------------------------------
@@ -17,6 +17,13 @@ CHUNK_SIZE = 1024
 SAMPLE_RATE = 16000
 BYTES_PER_FRAME = CHUNK_SIZE * 2  # int16 = 2 bytes per sample
 SILENCE_FRAME = b"\x00" * BYTES_PER_FRAME
+
+# Frame math:
+# frame_duration = 1024 / 16000 = 0.064s
+# min_chunk_s=2.0 → 32 frames (2.048s)
+# max_chunk_s=8.0 → 125 frames (8.0s)
+# silence_window_s=0.3 → frames_per_window = int(0.3/0.064) = 4
+# overlap_s=0.5 → overlap_frames = int(0.5/0.064) = 7
 
 
 def _speech_frame() -> bytes:
@@ -40,12 +47,13 @@ def mock_stt():
 def chunk_config():
     return ChunkConfig(
         enabled=True,
-        threshold_s=20.0,
+        min_chunk_s=2.0,
+        max_chunk_s=8.0,
+        overlap_s=0.5,
         silence_threshold=0.03,
         silence_window_s=0.3,
-        lookback_s=5.0,
-        chunk_size=1024,
-        sample_rate=16000,
+        chunk_size=CHUNK_SIZE,
+        sample_rate=SAMPLE_RATE,
         stt_timeout=120.0,
     )
 
@@ -56,22 +64,37 @@ def chunk_config():
 
 
 def test_short_recording_no_chunks(mock_stt, chunk_config):
-    """<20 s of audio does not dispatch any chunks and never calls STT."""
+    """Audio shorter than min_chunk_s does not dispatch any chunks."""
     manager = ChunkManager(mock_stt, chunk_config)
     manager.start_session()
-    # 200 frames × 0.064 s/frame = 12.8 s < 20 s threshold
-    for _ in range(200):
+    # 20 frames × 0.064s = 1.28s < 2.0s min
+    for _ in range(20):
         manager.feed_chunk(SILENCE_FRAME)
     assert not manager.has_chunks
     mock_stt.transcribe.assert_not_called()
 
 
-def test_threshold_triggers_chunk(mock_stt, chunk_config):
-    """25 s of audio triggers exactly one chunk dispatch."""
+def test_silence_cut_after_min(mock_stt, chunk_config):
+    """Speech > min_chunk_s then silence >= silence_window triggers dispatch."""
     manager = ChunkManager(mock_stt, chunk_config)
     manager.start_session()
-    # 391 frames × 0.064 s/frame ≈ 25 s > 20 s threshold
-    for _ in range(391):
+    # 35 speech frames = 2.24s > 2.0s min, then 5 silence frames (>= 4 window)
+    for _ in range(35):
+        manager.feed_chunk(_speech_frame())
+    for _ in range(5):
+        manager.feed_chunk(SILENCE_FRAME)
+    assert manager.has_chunks
+    for f in manager._futures:
+        f.result(timeout=5.0)
+    assert mock_stt.transcribe.call_count == 1
+
+
+def test_hard_cut_at_max(mock_stt, chunk_config):
+    """Continuous speech past max_chunk_s triggers hard cut dispatch."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # 126 speech frames = 8.064s > 8.0s max → hard cut
+    for _ in range(126):
         manager.feed_chunk(_speech_frame())
     assert manager.has_chunks
     for f in manager._futures:
@@ -79,110 +102,71 @@ def test_threshold_triggers_chunk(mock_stt, chunk_config):
     assert mock_stt.transcribe.call_count == 1
 
 
-def test_silence_detection_finds_gap(mock_stt, chunk_config):
-    """Silence gap inside a chunk causes the cut point to align with silence."""
+def test_overlap_boundary(mock_stt, chunk_config):
+    """After silence dispatch, _chunk_boundary == cut_point - overlap_frames."""
     manager = ChunkManager(mock_stt, chunk_config)
     manager.start_session()
-    # Frames 0–279: speech; frames 280–329: silence
-    for i in range(330):
-        frame = SILENCE_FRAME if i >= 280 else _speech_frame()
-        manager.feed_chunk(frame)
+    for _ in range(35):
+        manager.feed_chunk(_speech_frame())
+    for _ in range(5):
+        manager.feed_chunk(SILENCE_FRAME)
     assert manager.has_chunks
     for f in manager._futures:
         f.result(timeout=5.0)
+    # Infer cut_point from WAV data sent to STT
     wav_bytes = mock_stt.transcribe.call_args[0][0]
-    # WAV header = 44 bytes; remaining bytes are int16 PCM (2 bytes/sample)
-    wav_audio_bytes = len(wav_bytes) - 44
+    wav_audio_bytes = len(wav_bytes) - 44  # WAV header = 44 bytes
     frames_sent = wav_audio_bytes // BYTES_PER_FRAME
-    # silence_window_s=0.3 → 4 consecutive silent frames needed;
-    # cut lands at frame ~309 (silence starts at 280, scanner finds run at 309)
-    assert 275 <= frames_sent <= 315
+    overlap_frames = int(
+        chunk_config.overlap_s / (chunk_config.chunk_size / chunk_config.sample_rate)
+    )
+    assert overlap_frames == 7
+    # First dispatch starts at boundary 0, so cut_point == frames_sent
+    assert manager._chunk_boundary == frames_sent - overlap_frames
 
 
-def test_no_silence_fallback(mock_stt, chunk_config):
-    """Continuous noise with no silence falls back to cutting at the threshold position."""
-    manager = ChunkManager(mock_stt, chunk_config)
-    manager.start_session()
-    for _ in range(391):
-        manager.feed_chunk(_speech_frame())
-    assert manager.has_chunks
-    for f in manager._futures:
-        f.result(timeout=5.0)
-    wav_bytes = mock_stt.transcribe.call_args[0][0]
-    wav_audio_bytes = len(wav_bytes) - 44
-    frames_sent = wav_audio_bytes // BYTES_PER_FRAME
-    # Fallback: cut at int(20.0 × 16000 / 1024) = 312 frames
-    assert frames_sent == 312
-
-
-def test_finalize_concatenates_in_order(mock_stt, chunk_config):
-    """finalize() joins all chunk texts (dispatched + final) separated by spaces."""
-    manager = ChunkManager(mock_stt, chunk_config)
-    manager.start_session()
-    # 700 frames → 2 dispatches (at frames 313 and 625) + remaining final chunk
-    for _ in range(700):
-        manager.feed_chunk(_speech_frame())
-    assert manager.has_chunks
-    dummy_audio = np.zeros(100, dtype=np.float32)
-    result = manager.finalize(dummy_audio)
-    assert result is not None
-    # 3 chunks each returning "chunk text"; all three present in joined output
-    assert mock_stt.transcribe.call_count == 3
-    assert result.count("chunk text") == 3
-
-
-def test_cancel_discards_all(mock_stt, chunk_config):
-    """After cancel(), finalize() returns None regardless of buffered chunks."""
-    manager = ChunkManager(mock_stt, chunk_config)
-    manager.start_session()
-    for _ in range(391):
-        manager.feed_chunk(_speech_frame())
-    assert manager.has_chunks
-    manager.cancel()
-    dummy_audio = np.zeros(100, dtype=np.float32)
-    result = manager.finalize(dummy_audio)
-    assert result is None
-
-
-def test_provider_error_partial_results(mock_stt, chunk_config):
-    """A chunk that raises during transcription is skipped; other chunks contribute."""
+@patch("dicton.chunk_manager.time.sleep")
+def test_retry_on_failure(mock_sleep, mock_stt, chunk_config):
+    """_transcribe_chunk retries once; recovered text present in result."""
     call_count = [0]
-    lock = threading.Lock()
 
     def side_effect(_audio):
-        with lock:
-            n = call_count[0]
-            call_count[0] += 1
-        if n == 1:
-            raise RuntimeError("STT provider failure")
-        return TranscriptionResult(text=f"text{n}")
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise RuntimeError("temporary failure")
+        return TranscriptionResult(text="recovered text")
 
     mock_stt.transcribe.side_effect = side_effect
     manager = ChunkManager(mock_stt, chunk_config)
     manager.start_session()
-    for _ in range(700):
+    # Hard cut at 125 frames (8.0 s >= max); remaining overlap = 7 = 0.448 s < 0.5 s
+    for _ in range(125):
         manager.feed_chunk(_speech_frame())
-    dummy_audio = np.zeros(100, dtype=np.float32)
-    result = manager.finalize(dummy_audio)
-    assert mock_stt.transcribe.call_count == 3
-    assert result is not None
-    # Two successful chunks → two text segments joined by a single space
-    assert len(result.split(" ")) == 2
+    assert manager.has_chunks
+    result = manager.finalize()
+    assert result.text is not None
+    assert "recovered" in result.text
+    # 2 calls: first raised, second succeeded
+    assert mock_stt.transcribe.call_count == 2
+    mock_sleep.assert_called_once_with(1)
 
 
-def test_start_session_resets_state(mock_stt, chunk_config):
-    """start_session() fully resets internal state between recordings."""
+def test_finalize_returns_result(mock_stt, chunk_config):
+    """finalize returns FinalizeResult with correct text, counts, and is_partial."""
     manager = ChunkManager(mock_stt, chunk_config)
     manager.start_session()
-    for _ in range(391):
+    # Hard cut at 125 + enough remaining for finalize (> 0.5 s)
+    # 140 frames: boundary = 118, remaining = 22 = 1.408 s → finalize sends
+    for _ in range(140):
         manager.feed_chunk(_speech_frame())
-    dummy_audio = np.zeros(100, dtype=np.float32)
-    manager.finalize(dummy_audio)
-    manager.start_session()
-    assert manager._frames == []
-    assert manager._futures == []
-    assert manager._chunk_boundary == 0
-    assert not manager.has_chunks
+    assert manager.has_chunks
+    result = manager.finalize()
+    assert isinstance(result, FinalizeResult)
+    assert result.text is not None
+    assert "chunk text" in result.text
+    assert result.total_chunks == 2  # 1 dispatch + 1 finalize
+    assert result.failed_chunks == 0
+    assert result.is_partial is False
 
 
 def test_rms_computation(mock_stt, chunk_config):
@@ -198,19 +182,78 @@ def test_rms_computation(mock_stt, chunk_config):
     assert abs(manager._compute_rms(min_val) - 32768.0 / 8000.0) < 1e-4
 
 
-def test_short_final_chunk_skipped(mock_stt, chunk_config):
-    """Remaining audio < 0.5 s after the last dispatch is not sent to STT."""
+def test_cancel_discards_all(mock_stt, chunk_config):
+    """After cancel(), finalize() returns FinalizeResult with text=None."""
     manager = ChunkManager(mock_stt, chunk_config)
     manager.start_session()
-    # Dispatch at frame 313 (boundary → 312), then leave 5 frames = 0.32 s < 0.5 s
-    for _ in range(317):
+    for _ in range(126):
+        manager.feed_chunk(_speech_frame())
+    assert manager.has_chunks
+    manager.cancel()
+    result = manager.finalize()
+    assert isinstance(result, FinalizeResult)
+    assert result.text is None
+
+
+def test_start_session_resets_state(mock_stt, chunk_config):
+    """start_session() fully resets internal state between recordings."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    for _ in range(126):
+        manager.feed_chunk(_speech_frame())
+    manager.finalize()
+    manager.start_session()
+    assert manager._frames == []
+    assert manager._futures == []
+    assert manager._chunk_boundary == 0
+    assert manager._silent_run == 0
+    assert not manager.has_chunks
+
+
+@patch("dicton.chunk_manager.time.sleep")
+def test_provider_error_partial_results(_mock_sleep, mock_stt, chunk_config):
+    """One chunk fails both retries -> is_partial=True, failed_chunks=1."""
+    call_count = [0]
+    lock = threading.Lock()
+
+    def side_effect(_audio):
+        with lock:
+            n = call_count[0]
+            call_count[0] += 1
+        # Chunk 0 (dispatch 1): call 0 -> succeed
+        # Chunk 1 (dispatch 2): calls 1,2 -> both fail (retry exhausted)
+        # Chunk 2 (finalize):   call 3 -> succeed
+        if n in (1, 2):
+            raise RuntimeError("STT provider failure")
+        return TranscriptionResult(text=f"text{n}")
+
+    mock_stt.transcribe.side_effect = side_effect
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # 260 speech frames -> 2 hard-cut dispatches + finalize remaining > 0.5 s
+    for _ in range(260):
+        manager.feed_chunk(_speech_frame())
+    result = manager.finalize()
+    assert isinstance(result, FinalizeResult)
+    assert result.is_partial is True
+    assert result.failed_chunks == 1
+    assert result.text is not None
+
+
+def test_short_final_chunk_skipped(mock_stt, chunk_config):
+    """Remaining audio < 0.5s after the last dispatch is not sent to STT."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # Hard cut at frame 125 (8.0s >= 8.0s), boundary set back to 118 (overlap=7)
+    # Feed exactly 125: remaining = 125 - 118 = 7 frames = 0.448s < 0.5s
+    for _ in range(125):
         manager.feed_chunk(_speech_frame())
     assert manager.has_chunks
     for f in manager._futures:
         f.result(timeout=5.0)
     calls_before = mock_stt.transcribe.call_count
-    dummy_audio = np.zeros(100, dtype=np.float32)
-    result = manager.finalize(dummy_audio)
+    result = manager.finalize()
     # No additional STT call for the short final chunk
     assert mock_stt.transcribe.call_count == calls_before
-    assert result == "chunk text"
+    assert isinstance(result, FinalizeResult)
+    assert result.text == "chunk text"

--- a/tests/test_chunk_manager.py
+++ b/tests/test_chunk_manager.py
@@ -1,0 +1,216 @@
+"""Unit tests for src.dicton.chunk_manager."""
+
+import os
+import threading
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from dicton.chunk_manager import ChunkConfig, ChunkManager
+from dicton.stt_provider import TranscriptionResult
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+CHUNK_SIZE = 1024
+SAMPLE_RATE = 16000
+BYTES_PER_FRAME = CHUNK_SIZE * 2  # int16 = 2 bytes per sample
+SILENCE_FRAME = b"\x00" * BYTES_PER_FRAME
+
+
+def _speech_frame() -> bytes:
+    """Return random bytes that produce RMS >> 0.03 (speech-level audio)."""
+    return os.urandom(BYTES_PER_FRAME)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_stt():
+    provider = MagicMock()
+    provider.transcribe.return_value = TranscriptionResult(text="chunk text")
+    return provider
+
+
+@pytest.fixture
+def chunk_config():
+    return ChunkConfig(
+        enabled=True,
+        threshold_s=20.0,
+        silence_threshold=0.03,
+        silence_window_s=0.3,
+        lookback_s=5.0,
+        chunk_size=1024,
+        sample_rate=16000,
+        stt_timeout=120.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_short_recording_no_chunks(mock_stt, chunk_config):
+    """<20 s of audio does not dispatch any chunks and never calls STT."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # 200 frames × 0.064 s/frame = 12.8 s < 20 s threshold
+    for _ in range(200):
+        manager.feed_chunk(SILENCE_FRAME)
+    assert not manager.has_chunks
+    mock_stt.transcribe.assert_not_called()
+
+
+def test_threshold_triggers_chunk(mock_stt, chunk_config):
+    """25 s of audio triggers exactly one chunk dispatch."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # 391 frames × 0.064 s/frame ≈ 25 s > 20 s threshold
+    for _ in range(391):
+        manager.feed_chunk(_speech_frame())
+    assert manager.has_chunks
+    for f in manager._futures:
+        f.result(timeout=5.0)
+    assert mock_stt.transcribe.call_count == 1
+
+
+def test_silence_detection_finds_gap(mock_stt, chunk_config):
+    """Silence gap inside a chunk causes the cut point to align with silence."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # Frames 0–279: speech; frames 280–329: silence
+    for i in range(330):
+        frame = SILENCE_FRAME if i >= 280 else _speech_frame()
+        manager.feed_chunk(frame)
+    assert manager.has_chunks
+    for f in manager._futures:
+        f.result(timeout=5.0)
+    wav_bytes = mock_stt.transcribe.call_args[0][0]
+    # WAV header = 44 bytes; remaining bytes are int16 PCM (2 bytes/sample)
+    wav_audio_bytes = len(wav_bytes) - 44
+    frames_sent = wav_audio_bytes // BYTES_PER_FRAME
+    # silence_window_s=0.3 → 4 consecutive silent frames needed;
+    # cut lands at frame ~309 (silence starts at 280, scanner finds run at 309)
+    assert 275 <= frames_sent <= 315
+
+
+def test_no_silence_fallback(mock_stt, chunk_config):
+    """Continuous noise with no silence falls back to cutting at the threshold position."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    for _ in range(391):
+        manager.feed_chunk(_speech_frame())
+    assert manager.has_chunks
+    for f in manager._futures:
+        f.result(timeout=5.0)
+    wav_bytes = mock_stt.transcribe.call_args[0][0]
+    wav_audio_bytes = len(wav_bytes) - 44
+    frames_sent = wav_audio_bytes // BYTES_PER_FRAME
+    # Fallback: cut at int(20.0 × 16000 / 1024) = 312 frames
+    assert frames_sent == 312
+
+
+def test_finalize_concatenates_in_order(mock_stt, chunk_config):
+    """finalize() joins all chunk texts (dispatched + final) separated by spaces."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # 700 frames → 2 dispatches (at frames 313 and 625) + remaining final chunk
+    for _ in range(700):
+        manager.feed_chunk(_speech_frame())
+    assert manager.has_chunks
+    dummy_audio = np.zeros(100, dtype=np.float32)
+    result = manager.finalize(dummy_audio)
+    assert result is not None
+    # 3 chunks each returning "chunk text"; all three present in joined output
+    assert mock_stt.transcribe.call_count == 3
+    assert result.count("chunk text") == 3
+
+
+def test_cancel_discards_all(mock_stt, chunk_config):
+    """After cancel(), finalize() returns None regardless of buffered chunks."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    for _ in range(391):
+        manager.feed_chunk(_speech_frame())
+    assert manager.has_chunks
+    manager.cancel()
+    dummy_audio = np.zeros(100, dtype=np.float32)
+    result = manager.finalize(dummy_audio)
+    assert result is None
+
+
+def test_provider_error_partial_results(mock_stt, chunk_config):
+    """A chunk that raises during transcription is skipped; other chunks contribute."""
+    call_count = [0]
+    lock = threading.Lock()
+
+    def side_effect(_audio):
+        with lock:
+            n = call_count[0]
+            call_count[0] += 1
+        if n == 1:
+            raise RuntimeError("STT provider failure")
+        return TranscriptionResult(text=f"text{n}")
+
+    mock_stt.transcribe.side_effect = side_effect
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    for _ in range(700):
+        manager.feed_chunk(_speech_frame())
+    dummy_audio = np.zeros(100, dtype=np.float32)
+    result = manager.finalize(dummy_audio)
+    assert mock_stt.transcribe.call_count == 3
+    assert result is not None
+    # Two successful chunks → two text segments joined by a single space
+    assert len(result.split(" ")) == 2
+
+
+def test_start_session_resets_state(mock_stt, chunk_config):
+    """start_session() fully resets internal state between recordings."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    for _ in range(391):
+        manager.feed_chunk(_speech_frame())
+    dummy_audio = np.zeros(100, dtype=np.float32)
+    manager.finalize(dummy_audio)
+    manager.start_session()
+    assert manager._frames == []
+    assert manager._futures == []
+    assert manager._chunk_boundary == 0
+    assert not manager.has_chunks
+
+
+def test_rms_computation(mock_stt, chunk_config):
+    """_compute_rms returns expected values for silence and known amplitudes."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    # Silence: all zeros → RMS = 0
+    assert manager._compute_rms(SILENCE_FRAME) == 0.0
+    # Max int16 amplitude (32767) → RMS = 32767 / 8000
+    max_val = np.full(CHUNK_SIZE, 32767, dtype=np.int16).tobytes()
+    assert abs(manager._compute_rms(max_val) - 32767.0 / 8000.0) < 1e-4
+    # Min int16 amplitude (-32768) → RMS = 32768 / 8000
+    min_val = np.full(CHUNK_SIZE, -32768, dtype=np.int16).tobytes()
+    assert abs(manager._compute_rms(min_val) - 32768.0 / 8000.0) < 1e-4
+
+
+def test_short_final_chunk_skipped(mock_stt, chunk_config):
+    """Remaining audio < 0.5 s after the last dispatch is not sent to STT."""
+    manager = ChunkManager(mock_stt, chunk_config)
+    manager.start_session()
+    # Dispatch at frame 313 (boundary → 312), then leave 5 frames = 0.32 s < 0.5 s
+    for _ in range(317):
+        manager.feed_chunk(_speech_frame())
+    assert manager.has_chunks
+    for f in manager._futures:
+        f.result(timeout=5.0)
+    calls_before = mock_stt.transcribe.call_count
+    dummy_audio = np.zeros(100, dtype=np.float32)
+    result = manager.finalize(dummy_audio)
+    # No additional STT call for the short final chunk
+    assert mock_stt.transcribe.call_count == calls_before
+    assert result == "chunk text"


### PR DESCRIPTION
## Summary

- **Chunked STT pipeline** for long recordings: splits audio at silence boundaries during capture, transcribes chunks in parallel via ThreadPoolExecutor, and concatenates results. Short recordings (<20s) are completely unaffected. Achieves 60-80% perceived latency reduction for long recordings.
- **System tray icon** via AyatanaAppIndicator3 with color-coded state (idle/recording/processing/error), debug toggle, log viewer, and quit action.
- **File logging** via TeeWriter pattern — captures stdout/stderr to `~/.local/share/dicton/dicton.log` with 2MB rotation, zero changes to existing print calls. Essential for headless XDG autostart operation.
- **Visualizer floating in tiling WMs** (i3/sway): set `_NET_WM_WINDOW_TYPE_UTILITY` via Xlib before window mapping so i3 auto-floats instead of tiling. Added `set_resizable(False)` as fallback (i3 also floats windows with equal min/max size).
- **Visualizer color switching** fixed: session service now uses the correct backend-aware visualizer instance, GTK visualizer gained `set_colors()`, and a pending-color mechanism applies colors set before window creation.
- **Shared GTK main loop** between tray and visualizer — detects existing loop via `GLib.MainContext` instead of running competing `Gtk.main()` on separate threads.
- **PyInstaller bundling** for GTK/gi: injects system site-packages into pathex so PyGObject modules are found at build time.
- **Misc fixes**: numpy/list TypeError in processing animation, redundant STOP state transition, stale .deb artifact in release script, version regex in release script.

## Commits

| Hash | Description |
|------|-------------|
| `f1acb42` | feat: add chunked STT pipeline for long recordings |
| `9cc32ac` | fix: resolve stale .deb artifact picked up by release script |
| `7cc7d7a` | feat: overhaul chunked STT with sliding silence cut, overlap, and retry |
| `281aef0` | fix: version regex in release script missing space after equals |
| `041f327` | feat: add file logging and system tray icon for headless operation |
| `833aa04` | fix: add system site-packages to PyInstaller pathex for gi/GTK bundling |
| `ca60372` | fix: visualizer floats in tiling WMs, color switching, and GTK loop sharing |
| `9cee188` | fix: X11 window type via Xlib, pending color apply, tray idle color |
| `aed33ad` | fix: use UTILITY window type and realize() before map for i3 floating |
| `8f16855` | chore: bump version to 1.6.0 |

## Files changed

- `src/dicton/chunk_manager.py` — New: silence-based chunk splitting + parallel transcription
- `src/dicton/log_setup.py` — New: TeeWriter stdout/stderr capture with log rotation
- `src/dicton/tray.py` — New: AyatanaAppIndicator3 system tray with state observer
- `tests/test_chunk_manager.py` — New: 10 unit tests for chunk manager
- `src/dicton/visualizer_gtk.py` — UTILITY window type, realize() before map, set_colors(), shared GTK loop
- `src/dicton/visualizer.py` — UTILITY window type via Xlib for pygame backend
- `src/dicton/application/session_service.py` — Backend-aware visualizer color updates
- `src/dicton/application/runtime_service.py` — Tray + logging integration
- `src/dicton/core/controller.py` — Guard redundant STOP transition
- `src/dicton/core/state_machine.py` — Observer pattern for tray state notifications
- `src/dicton/adapters/audio.py` — Chunked pipeline injection via DI
- `src/dicton/bootstrap/container.py` — Wire chunk manager + tray into container
- `src/dicton/config.py` — 5 new CHUNK_* params + VISUALIZER_BACKEND
- `src/dicton/speech_recognition_engine.py` — Expose stt_provider + filter_text()
- `packaging/linux/dicton.spec` — Collect GTK/gi typelibs for PyInstaller
- `scripts/` — Release script fixes

## Test plan

- [x] Short recordings (<20s) work identically to before
- [ ] Long recordings (>30s) split at silence and transcribe in parallel
- [x] System tray shows correct state colors (idle=black, recording=orange, processing=blue)
- [x] Tray debug toggle, log viewer, and quit work
- [x] Visualizer floats in i3 (not tiled)
- [x] Visualizer color changes per mode (green for translation, etc.)
- [x] `dicton.log` captures all output in `~/.local/share/dicton/`
- [x] `.deb` package builds and installs cleanly