### PR TITLE
Fix 429 retry and chunked pipeline bypass

### DIFF
--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/adapters/audio.py
+++ b/src/dicton/adapters/audio.py
@@ -33,7 +33,7 @@ class STTAdapter:
         self._chunk_manager = chunk_manager
 
     def transcribe(self, audio):
-        if self._chunk_manager and self._chunk_manager.has_chunks:
+        if self._chunk_manager:
             result = self._chunk_manager.finalize()
             if result.is_partial:
                 logger.warning(

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -60,7 +60,9 @@ class ChunkManager:
     def __init__(self, stt_provider: STTProvider, config: ChunkConfig) -> None:
         self._stt = stt_provider
         self._config = config
-        self._executor = ThreadPoolExecutor(max_workers=3)
+        # Sequential dispatch (max_workers=1) to stay within Mistral's
+        # per-second rate limit on lower tiers (free tier = 1 RPS).
+        self._executor = ThreadPoolExecutor(max_workers=1)
 
         # Precompute frame-related constants
         self._frame_duration = config.chunk_size / config.sample_rate

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -149,19 +149,28 @@ class ChunkManager:
         data = np.frombuffer(raw_audio, dtype=np.int16).astype(np.float32)
         return float(np.sqrt(np.mean(data**2)) / config.RMS_NORMALIZATION)
 
+    _CHUNK_MAX_ATTEMPTS = 3
+    _CHUNK_RETRY_BASE_DELAY = 2.0  # doubles each attempt
+
     def _transcribe_chunk(self, frames: list[bytes], chunk_idx: int) -> str | None:
-        """Join frames, convert to WAV, transcribe with retry, return text or None."""
+        """Join frames, convert to WAV, transcribe with retry, return text or None.
+
+        Uses _raise_on_retryable=True so the STT provider propagates 429 /
+        capacity errors instead of swallowing them, letting us retry here with
+        exponential backoff.
+        """
         if self._cancelled:
             return None
         raw = b"".join(frames)
         audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
         wav_bytes = self._audio_to_wav(audio)
 
-        max_attempts = 2
-        for attempt in range(1, max_attempts + 1):
+        for attempt in range(1, self._CHUNK_MAX_ATTEMPTS + 1):
+            if self._cancelled:
+                return None
             t0 = time.monotonic()
             try:
-                result = self._stt.transcribe(wav_bytes)
+                result = self._stt.transcribe(wav_bytes, _raise_on_retryable=True)
                 latency = time.monotonic() - t0
                 text = result.text if result else None
                 logger.info(
@@ -177,13 +186,14 @@ class ChunkManager:
                     "Chunk %d attempt %d/%d failed (%.2fs)",
                     chunk_idx,
                     attempt,
-                    max_attempts,
+                    self._CHUNK_MAX_ATTEMPTS,
                     latency,
                 )
-                if attempt < max_attempts:
-                    time.sleep(1)
+                if attempt < self._CHUNK_MAX_ATTEMPTS:
+                    delay = self._CHUNK_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                    time.sleep(delay)
 
-        logger.error("Chunk %d: all %d attempts exhausted", chunk_idx, max_attempts)
+        logger.error("Chunk %d: all %d attempts exhausted", chunk_idx, self._CHUNK_MAX_ATTEMPTS)
         return None
 
     def _audio_to_wav(self, audio: np.ndarray) -> bytes:

--- a/src/dicton/fn_key_handler.py
+++ b/src/dicton/fn_key_handler.py
@@ -485,12 +485,6 @@ class FnKeyHandler:
                         if event.type != ecodes.EV_KEY:
                             continue
 
-                        # Debug: log key events
-                        if config.DEBUG:
-                            print(
-                                f"Key event from {device.name}: code={event.code} value={event.value}"
-                            )
-
                         # Track modifier key states
                         self._update_modifier_state(event.code, event.value)
 

--- a/src/dicton/stt_elevenlabs.py
+++ b/src/dicton/stt_elevenlabs.py
@@ -134,7 +134,7 @@ class ElevenLabsSTTProvider(STTProvider):
         # Reinitialize via is_available() which handles key change detection
         return self.is_available()
 
-    def transcribe(self, audio_data: bytes) -> TranscriptionResult | None:
+    def transcribe(self, audio_data: bytes, **kwargs) -> TranscriptionResult | None:
         """Transcribe audio data using ElevenLabs Scribe.
 
         Args:

--- a/src/dicton/stt_mistral.py
+++ b/src/dicton/stt_mistral.py
@@ -11,6 +11,7 @@ Key constraints:
 
 import hashlib
 import logging
+import time
 import wave
 from collections.abc import Callable, Iterator
 
@@ -144,11 +145,25 @@ class MistralSTTProvider(STTProvider):
         # Reinitialize via is_available() which handles key change detection
         return self.is_available()
 
-    def transcribe(self, audio_data: bytes) -> TranscriptionResult | None:
+    _MAX_RETRIES = 3
+    _RETRY_BASE_DELAY = 2.0  # seconds, doubles each attempt
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+        """Check if an API error is transient and worth retrying."""
+        msg = str(exc)
+        return "429" in msg or "capacity_exceeded" in msg or "rate_limit" in msg
+
+    def transcribe(
+        self, audio_data: bytes, *, _raise_on_retryable: bool = False
+    ) -> TranscriptionResult | None:
         """Transcribe audio data using Mistral Voxtral.
 
         Args:
             audio_data: Audio data as bytes (WAV or raw PCM int16).
+            _raise_on_retryable: If True, raise retryable errors instead of
+                retrying internally.  Used by ChunkManager so its own retry
+                loop can handle backoff.
 
         Returns:
             TranscriptionResult on success, None on failure.
@@ -168,68 +183,86 @@ class MistralSTTProvider(STTProvider):
         if wav_buffer is None:
             return None
 
-        try:
-            # Debug output for verification
-            from .config import config as app_config
+        wav_content = wav_buffer.read()
 
-            if app_config.DEBUG:
-                wav_buffer.seek(0, 2)  # Seek to end
-                audio_size = wav_buffer.tell()
-                wav_buffer.seek(0)  # Reset
-                print(
-                    f"[Mistral] 🔄 Calling API: model={self._config.model}, audio={audio_size} bytes"
-                )
+        from .config import config as app_config
 
-            # Call Mistral API
-            # Note: Cannot use language + timestamp_granularities together
-            result = self._client.audio.transcriptions.complete(
-                model=self._config.model,
-                file={"content": wav_buffer.read(), "file_name": "audio.wav"},
+        if app_config.DEBUG:
+            print(
+                f"[Mistral] Calling API: model={self._config.model}, audio={len(wav_content)} bytes"
             )
 
-            if app_config.DEBUG:
-                print(
-                    f"[Mistral] ✓ Response received: {len(result.text) if result and hasattr(result, 'text') else 0} chars"
-                )
+        last_exc: Exception | None = None
+        max_attempts = 1 if _raise_on_retryable else self._MAX_RETRIES
 
-            if not result or not hasattr(result, "text"):
-                logger.warning("Mistral returned no text")
-                return None
-
-            # Build result
-            transcription = TranscriptionResult(
-                text=result.text or "",
-                language=getattr(result, "language", "") or "",
-                is_final=True,
-            )
-
-            # Extract word timestamps if available
-            if hasattr(result, "words") and result.words:
-                transcription.words = [
-                    WordInfo(
-                        word=w.word,
-                        start=w.start,
-                        end=w.end,
-                        confidence=getattr(w, "confidence", 1.0),
-                    )
-                    for w in result.words
-                ]
-
-            # Calculate duration from audio
-            wav_buffer.seek(0)
+        for attempt in range(1, max_attempts + 1):
             try:
-                with wave.open(wav_buffer, "rb") as wav:
-                    frames = wav.getnframes()
-                    rate = wav.getframerate()
-                    transcription.duration = frames / rate
+                # Call Mistral API
+                # Note: Cannot use language + timestamp_granularities together
+                result = self._client.audio.transcriptions.complete(
+                    model=self._config.model,
+                    file={"content": wav_content, "file_name": "audio.wav"},
+                )
+
+                if app_config.DEBUG:
+                    chars = len(result.text) if result and hasattr(result, "text") else 0
+                    print(f"[Mistral] Response received: {chars} chars")
+
+                if not result or not hasattr(result, "text"):
+                    logger.warning("Mistral returned no text")
+                    return None
+
+                # Build result
+                transcription = TranscriptionResult(
+                    text=result.text or "",
+                    language=getattr(result, "language", "") or "",
+                    is_final=True,
+                )
+
+                # Extract word timestamps if available
+                if hasattr(result, "words") and result.words:
+                    transcription.words = [
+                        WordInfo(
+                            word=w.word,
+                            start=w.start,
+                            end=w.end,
+                            confidence=getattr(w, "confidence", 1.0),
+                        )
+                        for w in result.words
+                    ]
+
+                # Calculate duration from audio
+                wav_buffer.seek(0)
+                try:
+                    with wave.open(wav_buffer, "rb") as wav:
+                        frames = wav.getnframes()
+                        rate = wav.getframerate()
+                        transcription.duration = frames / rate
+                except Exception as e:
+                    logger.debug(f"Could not calculate audio duration: {e}")
+
+                return transcription
+
             except Exception as e:
-                logger.debug(f"Could not calculate audio duration: {e}")
+                last_exc = e
+                if self._is_retryable(e):
+                    if _raise_on_retryable:
+                        raise
+                    if attempt < max_attempts:
+                        delay = self._RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                        logger.warning(
+                            "Mistral 429 — retrying in %.0fs (attempt %d/%d)",
+                            delay,
+                            attempt,
+                            max_attempts,
+                        )
+                        time.sleep(delay)
+                        continue
+                # Non-retryable or exhausted retries
+                break
 
-            return transcription
-
-        except Exception as e:
-            logger.error(f"Mistral transcription failed: {e}")
-            return None
+        logger.error("Mistral transcription failed: %s", last_exc)
+        return None
 
     def stream_transcribe(
         self,

--- a/src/dicton/stt_provider.py
+++ b/src/dicton/stt_provider.py
@@ -184,11 +184,12 @@ class STTProvider(ABC):
         return True
 
     @abstractmethod
-    def transcribe(self, audio_data: bytes) -> TranscriptionResult | None:
+    def transcribe(self, audio_data: bytes, **kwargs) -> TranscriptionResult | None:
         """Transcribe audio data (batch mode).
 
         Args:
             audio_data: Audio data as bytes (typically WAV format).
+            **kwargs: Provider-specific options (e.g. _raise_on_retryable).
 
         Returns:
             TranscriptionResult on success, None on failure.
@@ -296,7 +297,7 @@ class NullSTTProvider(STTProvider):
     def is_available(self) -> bool:
         return True  # Always "available" as a fallback
 
-    def transcribe(self, audio_data: bytes) -> TranscriptionResult | None:
+    def transcribe(self, audio_data: bytes, **kwargs) -> TranscriptionResult | None:
         return None
 
     def stream_transcribe(

--- a/tests/test_chunk_manager.py
+++ b/tests/test_chunk_manager.py
@@ -127,10 +127,10 @@ def test_overlap_boundary(mock_stt, chunk_config):
 
 @patch("dicton.chunk_manager.time.sleep")
 def test_retry_on_failure(mock_sleep, mock_stt, chunk_config):
-    """_transcribe_chunk retries once; recovered text present in result."""
+    """_transcribe_chunk retries on transient error; recovered text present in result."""
     call_count = [0]
 
-    def side_effect(_audio):
+    def side_effect(_audio, **kwargs):
         call_count[0] += 1
         if call_count[0] == 1:
             raise RuntimeError("temporary failure")
@@ -148,7 +148,7 @@ def test_retry_on_failure(mock_sleep, mock_stt, chunk_config):
     assert "recovered" in result.text
     # 2 calls: first raised, second succeeded
     assert mock_stt.transcribe.call_count == 2
-    mock_sleep.assert_called_once_with(1)
+    mock_sleep.assert_called_once_with(2.0)
 
 
 def test_finalize_returns_result(mock_stt, chunk_config):
@@ -212,18 +212,18 @@ def test_start_session_resets_state(mock_stt, chunk_config):
 
 @patch("dicton.chunk_manager.time.sleep")
 def test_provider_error_partial_results(_mock_sleep, mock_stt, chunk_config):
-    """One chunk fails both retries -> is_partial=True, failed_chunks=1."""
+    """One chunk fails all retries -> is_partial=True, failed_chunks=1."""
     call_count = [0]
     lock = threading.Lock()
 
-    def side_effect(_audio):
+    def side_effect(_audio, **kwargs):
         with lock:
             n = call_count[0]
             call_count[0] += 1
         # Chunk 0 (dispatch 1): call 0 -> succeed
-        # Chunk 1 (dispatch 2): calls 1,2 -> both fail (retry exhausted)
-        # Chunk 2 (finalize):   call 3 -> succeed
-        if n in (1, 2):
+        # Chunk 1 (dispatch 2): calls 1,2,3 -> all fail (3 retries exhausted)
+        # Chunk 2 (finalize):   call 4 -> succeed
+        if n in (1, 2, 3):
             raise RuntimeError("STT provider failure")
         return TranscriptionResult(text=f"text{n}")
 


### PR DESCRIPTION
## Root cause

Mistral free tier has a **1 request per second** limit. The chunk pipeline was using `ThreadPoolExecutor(max_workers=3)`, sending up to 3 concurrent API requests — guaranteed 429 on free tier.

Additionally, `STTAdapter` bypassed `finalize()` entirely for continuous speech under 120s (no chunks dispatched during recording), so the audio was sent as one un-retried request.

## Fixes

- **Serialize chunk dispatch**: `max_workers=1` so chunks are sent sequentially, respecting 1 RPS
- **Always route through chunk pipeline**: Removed `has_chunks` guard in STTAdapter — `finalize()` is always called when chunk_manager exists
- **429 retry with exponential backoff**: `stt_mistral.transcribe()` retries 429/capacity errors (2s → 4s → 8s, 3 attempts)
- **chunk_manager retry actually works**: Uses `_raise_on_retryable=True` so transient errors propagate to the chunk retry loop instead of being silently swallowed
- **Removed noisy key-event debug logging** from fn_key_handler
- **Version bump to 1.7.0**

## Test plan

- [ ] Record continuous speech >30s — verify it goes through finalize() path
- [ ] Verify no 429 errors on free tier with sequential dispatch
- [ ] Verify key events no longer spam stdout in debug mode
- [ ] Verify normal short recordings still work