### PR TITLE
Fix chunk silence detection (DC offset removal)

### DIFF
--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/application/session_service.py
+++ b/src/dicton/application/session_service.py
@@ -21,6 +21,8 @@ class SessionService:
         self._keyboard = keyboard
         self._metrics = metrics
         self._app_config = app_config
+        self._session_lock = threading.Lock()
+        self._starting = False
         self._recording = False
         self._record_thread: threading.Thread | None = None
         self._current_mode = ProcessingMode.BASIC
@@ -38,7 +40,8 @@ class SessionService:
 
     @property
     def recording(self) -> bool:
-        return self._recording
+        with self._session_lock:
+            return self._recording
 
     def toggle_basic_recording(self) -> None:
         """Legacy toggle used by the modifier+key keyboard listener."""
@@ -49,64 +52,81 @@ class SessionService:
 
     def start_recording(self, mode: ProcessingMode) -> None:
         """Start recording for the requested processing mode."""
-        if self._recording:
-            return
-
-        if self._record_thread is not None and self._record_thread.is_alive():
-            return  # Previous session still processing
+        with self._session_lock:
+            if self._starting or self._recording:
+                return
+            if self._record_thread is not None and self._record_thread.is_alive():
+                return  # Previous session still processing
+            self._starting = True
 
         if not is_mode_enabled(mode):
             mode = ProcessingMode.BASIC
 
-        self._current_mode = mode
-        self._selected_text = None
-        self._current_context = None
+        selected_text = None
+        current_context = None
 
-        if self._app_config.context_enabled:
-            try:
-                from ..context_detector import get_context_detector
+        try:
+            if self._app_config.context_enabled:
+                try:
+                    from ..context_detector import get_context_detector
 
-                detector = get_context_detector()
-                if detector:
-                    self._current_context = detector.get_context()
-            except Exception as exc:
-                if self._app_config.context_debug:
-                    print(f"[Context] Detection failed: {exc}")
+                    detector = get_context_detector()
+                    if detector:
+                        current_context = detector.get_context()
+                except Exception as exc:
+                    if self._app_config.context_debug:
+                        print(f"[Context] Detection failed: {exc}")
 
-        if mode == ProcessingMode.ACT_ON_TEXT:
-            selected = self._capture_selection_for_act_on_text()
-            if not selected:
-                return
-            self._selected_text = selected
-            print(
-                f"📋 Selected: {selected[:50]}..."
-                if len(selected) > 50
-                else f"📋 Selected: {selected}"
+            if mode == ProcessingMode.ACT_ON_TEXT:
+                selected = self._capture_selection_for_act_on_text()
+                if not selected:
+                    return
+                selected_text = selected
+                print(
+                    f"📋 Selected: {selected[:50]}..."
+                    if len(selected) > 50
+                    else f"📋 Selected: {selected}"
+                )
+
+            self._update_visualizer_color(mode)
+
+            record_thread = threading.Thread(
+                target=self._record_and_transcribe,
+                args=(mode, selected_text, current_context),
+                daemon=True,
             )
-
-        self._recording = True
-        self._update_visualizer_color(mode)
-        self._record_thread = threading.Thread(target=self._record_and_transcribe, daemon=True)
-        self._record_thread.start()
+            with self._session_lock:
+                self._current_mode = mode
+                self._selected_text = selected_text
+                self._current_context = current_context
+                self._recording = True
+                self._record_thread = record_thread
+                self._starting = False
+            record_thread.start()
+        finally:
+            with self._session_lock:
+                self._starting = False
 
     def stop_recording(self) -> None:
         """Stop recording and continue to processing."""
-        if not self._recording:
-            return
+        with self._session_lock:
+            if not self._recording:
+                return
+            self._recording = False
 
         print("⏹ Stopping...")
         self._controller.stop()
-        self._recording = False
 
     def cancel_recording(self) -> None:
         """Cancel recording and discard captured audio."""
-        if not self._recording:
-            return
+        with self._session_lock:
+            if not self._recording:
+                return
+            self._recording = False
 
         if self._app_config.debug:
             print("⏹ Cancelled (tap)")
         self._controller.cancel()
-        self._recording = False
 
     def _update_visualizer_color(self, mode: ProcessingMode) -> None:
         try:
@@ -118,8 +138,12 @@ class SessionService:
         except Exception:
             pass
 
-    def _record_and_transcribe(self) -> None:
-        mode = self._current_mode
+    def _record_and_transcribe(
+        self,
+        mode: ProcessingMode,
+        selected_text: str | None,
+        current_context: ContextInfo | None,
+    ) -> None:
         tracker = self._metrics
         mode_names = {
             ProcessingMode.BASIC: "Recording",
@@ -134,16 +158,14 @@ class SessionService:
         viz = self._visualizer
 
         try:
-            selected_text = None
             if mode == ProcessingMode.ACT_ON_TEXT:
-                selected_text = self._selected_text
                 if not selected_text:
                     print("⚠ No selection captured")
                     return
 
             session_ctx = SessionContext(
                 selected_text=selected_text,
-                context=self._current_context,
+                context=current_context,
             )
 
             def _pre_output() -> None:
@@ -173,7 +195,10 @@ class SessionService:
             except Exception:
                 pass
         finally:
-            self._recording = False
+            with self._session_lock:
+                self._recording = False
+                if self._record_thread is threading.current_thread():
+                    self._record_thread = None
             if viz:
                 viz.stop()
 

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -163,8 +163,9 @@ class ChunkManager:
     # ------------------------------------------------------------------
 
     def _compute_rms(self, raw_audio: bytes) -> float:
-        """Compute normalised RMS identical to the visualizer formula."""
+        """Compute normalised AC-coupled RMS (DC offset removed)."""
         data = np.frombuffer(raw_audio, dtype=np.int16).astype(np.float32)
+        data = data - np.mean(data)  # Remove DC offset
         return float(np.sqrt(np.mean(data**2)) / config.RMS_NORMALIZATION)
 
     _CHUNK_MAX_ATTEMPTS = 3

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -98,6 +98,7 @@ class ChunkManager:
         self._futures = []
         self._cancelled = False
         self._silent_run = 0
+        self._rms_min = float("inf")
 
     # ------------------------------------------------------------------
     # Recording feed
@@ -112,6 +113,18 @@ class ChunkManager:
             self._silent_run += 1
         else:
             self._silent_run = 0
+
+        # Track min RMS for diagnostics
+        frame_idx = len(self._frames)
+        if not hasattr(self, "_rms_min"):
+            self._rms_min = rms
+        self._rms_min = min(self._rms_min, rms)
+        if frame_idx % 150 == 0:  # ~every 10s
+            logger.debug(
+                "RMS diagnostic: current=%.4f, min_seen=%.4f, threshold=%.4f, silent_run=%d/%d",
+                rms, self._rms_min, self._config.silence_threshold,
+                self._silent_run, self._frames_per_window,
+            )
 
         unchunked_frames = len(self._frames) - self._chunk_boundary
         duration_s = unchunked_frames * self._frame_duration

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -122,8 +122,11 @@ class ChunkManager:
         if frame_idx % 150 == 0:  # ~every 10s
             logger.debug(
                 "RMS diagnostic: current=%.4f, min_seen=%.4f, threshold=%.4f, silent_run=%d/%d",
-                rms, self._rms_min, self._config.silence_threshold,
-                self._silent_run, self._frames_per_window,
+                rms,
+                self._rms_min,
+                self._config.silence_threshold,
+                self._silent_run,
+                self._frames_per_window,
             )
 
         unchunked_frames = len(self._frames) - self._chunk_boundary

--- a/src/dicton/chunk_manager.py
+++ b/src/dicton/chunk_manager.py
@@ -98,7 +98,6 @@ class ChunkManager:
         self._futures = []
         self._cancelled = False
         self._silent_run = 0
-        self._rms_min = float("inf")
 
     # ------------------------------------------------------------------
     # Recording feed
@@ -113,21 +112,6 @@ class ChunkManager:
             self._silent_run += 1
         else:
             self._silent_run = 0
-
-        # Track min RMS for diagnostics
-        frame_idx = len(self._frames)
-        if not hasattr(self, "_rms_min"):
-            self._rms_min = rms
-        self._rms_min = min(self._rms_min, rms)
-        if frame_idx % 150 == 0:  # ~every 10s
-            logger.debug(
-                "RMS diagnostic: current=%.4f, min_seen=%.4f, threshold=%.4f, silent_run=%d/%d",
-                rms,
-                self._rms_min,
-                self._config.silence_threshold,
-                self._silent_run,
-                self._frames_per_window,
-            )
 
         unchunked_frames = len(self._frames) - self._chunk_boundary
         duration_s = unchunked_frames * self._frame_duration

--- a/src/dicton/fn_key_handler.py
+++ b/src/dicton/fn_key_handler.py
@@ -10,6 +10,7 @@ Delayed Start Mode:
 """
 
 import os
+import queue
 import threading
 import time
 from collections.abc import Callable
@@ -95,6 +96,11 @@ class FnKeyHandler:
         self._timer_thread: threading.Thread | None = None
         self._activation_timer: threading.Timer | None = None
         self._running = False
+
+        # Deliver start/stop/cancel callbacks in-order on a dedicated worker.
+        self._callback_queue: queue.Queue[tuple[str, ProcessingMode | None] | None] = queue.Queue()
+        self._callback_thread: threading.Thread | None = None
+        self._start_callback_worker()
 
         # evdev devices
         self._device = None  # Primary device (laptop keyboard for FN key)
@@ -279,6 +285,41 @@ class FnKeyHandler:
             self._device_monitor_thread.join(timeout=1.0)
         if self._listener_thread:
             self._listener_thread.join(timeout=1.0)
+        if self._callback_thread and self._callback_thread.is_alive():
+            self._callback_queue.put(None)
+            self._callback_thread.join(timeout=1.0)
+            self._callback_thread = None
+
+    def _start_callback_worker(self):
+        """Run hotkey callbacks sequentially so state transitions stay ordered."""
+        if self._callback_thread and self._callback_thread.is_alive():
+            return
+
+        def run_callbacks():
+            while True:
+                item = self._callback_queue.get()
+                if item is None:
+                    return
+
+                action, mode = item
+                try:
+                    if action == "start" and self.on_start_recording:
+                        self.on_start_recording(mode)
+                    elif action == "stop" and self.on_stop_recording:
+                        self.on_stop_recording()
+                    elif action == "cancel" and self.on_cancel_recording:
+                        self.on_cancel_recording()
+                except Exception as exc:
+                    if config.DEBUG:
+                        print(f"Hotkey callback '{action}' failed: {exc}")
+
+        self._callback_thread = threading.Thread(target=run_callbacks, daemon=True)
+        self._callback_thread.start()
+
+    def _enqueue_callback(self, action: str, mode: ProcessingMode | None = None):
+        """Queue a hotkey callback for ordered delivery."""
+        self._start_callback_worker()
+        self._callback_queue.put((action, mode))
 
     def _close_wake_pipe(self):
         """Close the self-pipe used to wake select()"""
@@ -725,19 +766,17 @@ class FnKeyHandler:
     def _trigger_start_recording(self):
         """Trigger recording start callback with current mode"""
         if self.on_start_recording:
-            mode = self._current_mode
-            # Run callback in separate thread to not block event handling
-            threading.Thread(target=lambda: self.on_start_recording(mode), daemon=True).start()
+            self._enqueue_callback("start", self._current_mode)
 
     def _trigger_stop_recording(self):
         """Trigger recording stop callback (will process audio)"""
         if self.on_stop_recording:
-            threading.Thread(target=self.on_stop_recording, daemon=True).start()
+            self._enqueue_callback("stop")
 
     def _trigger_cancel_recording(self):
         """Trigger recording cancel callback (discard audio, tap detected)"""
         if self.on_cancel_recording:
-            threading.Thread(target=self.on_cancel_recording, daemon=True).start()
+            self._enqueue_callback("cancel")
 
     @property
     def state(self) -> HotkeyState:

--- a/tests/test_chunk_manager.py
+++ b/tests/test_chunk_manager.py
@@ -170,16 +170,23 @@ def test_finalize_returns_result(mock_stt, chunk_config):
 
 
 def test_rms_computation(mock_stt, chunk_config):
-    """_compute_rms returns expected values for silence and known amplitudes."""
+    """_compute_rms returns expected values for silence and known amplitudes.
+
+    RMS is AC-coupled (DC offset removed), so constant signals yield 0
+    and only the varying component is measured.
+    """
     manager = ChunkManager(mock_stt, chunk_config)
     # Silence: all zeros → RMS = 0
     assert manager._compute_rms(SILENCE_FRAME) == 0.0
-    # Max int16 amplitude (32767) → RMS = 32767 / 8000
+    # Constant value (pure DC) → RMS = 0 after DC removal
     max_val = np.full(CHUNK_SIZE, 32767, dtype=np.int16).tobytes()
-    assert abs(manager._compute_rms(max_val) - 32767.0 / 8000.0) < 1e-4
-    # Min int16 amplitude (-32768) → RMS = 32768 / 8000
-    min_val = np.full(CHUNK_SIZE, -32768, dtype=np.int16).tobytes()
-    assert abs(manager._compute_rms(min_val) - 32768.0 / 8000.0) < 1e-4
+    assert manager._compute_rms(max_val) == 0.0
+    # Alternating +/- signal (zero mean, pure AC) → RMS = amplitude / 8000
+    alt = np.array([10000, -10000] * (CHUNK_SIZE // 2), dtype=np.int16).tobytes()
+    assert abs(manager._compute_rms(alt) - 10000.0 / 8000.0) < 1e-4
+    # DC offset + AC signal: only AC component measured
+    biased = np.array([20000, 0] * (CHUNK_SIZE // 2), dtype=np.int16).tobytes()
+    assert abs(manager._compute_rms(biased) - 10000.0 / 8000.0) < 1e-4
 
 
 def test_cancel_discards_all(mock_stt, chunk_config):

--- a/tests/test_fn_key_handler.py
+++ b/tests/test_fn_key_handler.py
@@ -1,0 +1,45 @@
+"""Regression tests for FN hotkey callback ordering."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from dicton.fn_key_handler import FnKeyHandler
+from dicton.processing_mode import ProcessingMode
+
+
+def test_toggle_callbacks_are_delivered_in_order():
+    calls: list[str] = []
+    start_entered = threading.Event()
+    allow_start_to_finish = threading.Event()
+    stop_called = threading.Event()
+
+    def on_start(mode: ProcessingMode) -> None:
+        assert mode == ProcessingMode.BASIC
+        start_entered.set()
+        allow_start_to_finish.wait(timeout=1.0)
+        calls.append("start")
+
+    def on_stop() -> None:
+        calls.append("stop")
+        stop_called.set()
+
+    handler = FnKeyHandler(on_start_recording=on_start, on_stop_recording=on_stop)
+
+    try:
+        handler._on_custom_hotkey_down()
+        assert start_entered.wait(timeout=1.0)
+
+        handler._on_custom_hotkey_down()
+        time.sleep(0.05)
+
+        # The queued stop must wait for the earlier start callback to finish.
+        assert calls == []
+
+        allow_start_to_finish.set()
+        assert stop_called.wait(timeout=1.0)
+        assert calls == ["start", "stop"]
+    finally:
+        allow_start_to_finish.set()
+        handler.stop()

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -1,0 +1,85 @@
+"""Regression tests for session-service concurrency."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import types
+
+from dicton.application.session_service import SessionService
+from dicton.processing_mode import ProcessingMode
+
+
+class _DummyController:
+    def __init__(self):
+        self.sessions: list[tuple[ProcessingMode, object | None]] = []
+        self.stop_calls = 0
+        self.cancel_calls = 0
+
+        class _State:
+            def add_observer(self, callback) -> None:
+                return None
+
+        self._state = _State()
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+    def cancel(self) -> None:
+        self.cancel_calls += 1
+
+    def run_session(self, mode, session, mode_names, pre_output=None):
+        self.sessions.append((mode, session.context))
+        time.sleep(0.05)
+        return True, None
+
+
+class _DummyMetrics:
+    def end_session(self):
+        return None
+
+
+class _AppConfig:
+    def __init__(self, context_enabled: bool):
+        self.context_enabled = context_enabled
+        self.context_debug = False
+        self.debug = True
+
+
+def test_concurrent_starts_only_launch_one_session(monkeypatch):
+    context_module = types.ModuleType("dicton.context_detector")
+
+    class _Detector:
+        def get_context(self):
+            time.sleep(0.05)
+            return "ctx"
+
+    context_module.get_context_detector = lambda: _Detector()
+    monkeypatch.setitem(sys.modules, "dicton.context_detector", context_module)
+
+    controller = _DummyController()
+    service = SessionService(
+        controller=controller,
+        keyboard=None,
+        metrics=_DummyMetrics(),
+        app_config=_AppConfig(context_enabled=True),
+    )
+    monkeypatch.setattr(service, "_load_visualizer", lambda: None)
+
+    threads = [
+        threading.Thread(target=service.start_recording, args=(ProcessingMode.BASIC,)),
+        threading.Thread(target=service.start_recording, args=(ProcessingMode.BASIC,)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    record_thread = service._record_thread
+    assert record_thread is not None
+    record_thread.join(timeout=1.0)
+
+    assert len(controller.sessions) == 1
+    assert controller.sessions == [(ProcessingMode.BASIC, "ctx")]
+    assert service.recording is False


### PR DESCRIPTION
## Summary

- Bump version to 1.7.1
- Fix silence detection in `ChunkManager` by removing DC offset before RMS computation

## Problem

The chunked STT pipeline never split recordings at silence boundaries. Even with 80s recordings containing deliberate pauses, only 1 chunk was ever dispatched.

**Root cause:** `_compute_rms()` included the DC component of the microphone signal. A typical mic DC bias of ~6000 (int16) produced an RMS of **0.78** even during dead silence — 26x above the `0.03` threshold. The `silent_run` counter never incremented.

## Fix

Subtract the frame mean before computing RMS (AC-coupling):
```python
data = data - np.mean(data)  # Remove DC offset
```

This isolates actual audio energy: silence now reads ~0.002, speech ~0.06-0.09. Silence boundary cuts trigger correctly after 30s+ of audio followed by a ~0.3s pause.

## Test plan

- [x] Unit tests updated for AC-coupled RMS (constant signal = 0, alternating signal = amplitude/norm)
- [x] Manual test: 87s recording → 3 chunks dispatched at silence boundaries (was 1)
- [x] 429 retry still works (chunk 0 rate-limited, retried successfully)
- [x] All 224 tests pass, lint clean