### PR TITLE
Fix STT factory fallback chain ignoring configured providers

### DIFF
--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/stt_factory.py
+++ b/src/dicton/stt_factory.py
@@ -128,7 +128,7 @@ def get_stt_provider_with_fallback(
 
     # Check for user-specified provider first
     user_provider = os.getenv("STT_PROVIDER", "").lower()
-    if user_provider:
+    if user_provider and user_provider != "auto":
         provider = get_stt_provider(user_provider, config)
         if provider.is_available():
             if verbose:

--- a/src/dicton/stt_provider.py
+++ b/src/dicton/stt_provider.py
@@ -295,7 +295,7 @@ class NullSTTProvider(STTProvider):
         return set()
 
     def is_available(self) -> bool:
-        return True  # Always "available" as a fallback
+        return False  # Null provider is never a real provider
 
     def transcribe(self, audio_data: bytes, **kwargs) -> TranscriptionResult | None:
         return None

--- a/tests/test_stt_factory.py
+++ b/tests/test_stt_factory.py
@@ -153,6 +153,26 @@ class TestSTTFactoryFallback:
             provider = get_stt_provider_with_fallback()
             assert provider.name == "Mistral Voxtral"
 
+    def test_auto_provider_uses_fallback_chain(self):
+        """Test STT_PROVIDER=auto triggers fallback chain, not literal lookup."""
+        mock_mistral_module = MagicMock()
+        mock_mistral_class = MagicMock()
+        mock_mistral_module.Mistral = mock_mistral_class
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"STT_PROVIDER": "auto", "MISTRAL_API_KEY": "test_key"},
+                clear=False,
+            ),
+            patch.dict("sys.modules", {"mistralai": mock_mistral_module}),
+        ):
+            from dicton.stt_factory import get_stt_provider_with_fallback
+
+            provider = get_stt_provider_with_fallback()
+            # "auto" should use fallback chain and find mistral, not return NullSTTProvider
+            assert provider.name == "Mistral Voxtral"
+
 
 class TestSTTFactoryAvailable:
     """Test getting list of available providers."""


### PR DESCRIPTION
## Summary

- **NullSTTProvider.is_available()** returned `True`, short-circuiting the fallback chain before real providers were tried
- **STT_PROVIDER=auto** (the default) was treated as a literal provider name lookup instead of triggering the fallback chain
- Combined effect: factory always returned NullSTTProvider — dictation never worked regardless of API keys

## Changes

- `NullSTTProvider.is_available()` → returns `False`
- Factory treats `"auto"` as unset (uses fallback chain)
- Regression test for `STT_PROVIDER=auto`

## Test plan

- [x] All 204 tests pass
- [x] Lint clean
- [ ] Manual: set `ELEVENLABS_API_KEY`, verify provider is detected on startup