### PR TITLE
fix: bundle evdev/pyudev and fix _gi in PyInstaller for Wayland/GNOME

### DIFF
--- a/packaging/linux/dicton.spec
+++ b/packaging/linux/dicton.spec
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs, collect_submodules
 
 
 spec_dir = Path(globals().get("SPECPATH", Path.cwd())).resolve()
@@ -13,7 +13,6 @@ datas = collect_data_files(
         "assets/setup_ui.html",
         "assets/config_ui.html",
         "assets/logo.png",
-        "default_contexts.json",
     ],
 )
 datas += [
@@ -21,18 +20,11 @@ datas += [
     (str(project_root / "README.md"), "."),
 ]
 
-hiddenimports = [
-    "dicton.config_server",
-    "dicton.context_detector_wayland",
-    "dicton.context_detector_x11",
-    "dicton.log_setup",
-    "dicton.main",
-    "dicton.stt_elevenlabs",
-    "dicton.stt_mistral",
-    "dicton.tray",
-]
+hiddenimports = []
 hiddenimports += collect_submodules("pynput")
 hiddenimports += collect_submodules("Xlib")
+hiddenimports += collect_submodules("evdev")
+hiddenimports += collect_submodules("pyudev")
 
 # Collect GTK/gi typelibs for the system tray.
 # PyGObject (gi) is a system apt package in /usr/lib/python3/dist-packages/,
@@ -80,6 +72,8 @@ except Exception:
 try:
     hiddenimports += collect_submodules("gi")
     hiddenimports += collect_submodules("cairo")
+    binaries += collect_dynamic_libs("gi")
+    binaries += collect_dynamic_libs("cairo")
 except Exception:
     pass
 

--- a/scripts/build-linux-package.sh
+++ b/scripts/build-linux-package.sh
@@ -59,6 +59,26 @@ Description: Voice-to-text dictation with direct transcription and translation
  translation to English, packaged here as a Linux one-folder bundle.
 EOF
 
+cat > "${STAGE_DIR}/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+
+# Check if the installing user is in the 'input' group
+SUDO_USER="${SUDO_USER:-$(logname 2>/dev/null || echo '')}"
+if [ -n "$SUDO_USER" ]; then
+    if ! groups "$SUDO_USER" 2>/dev/null | grep -qw input; then
+        echo ""
+        echo "╔══════════════════════════════════════════════════════════════╗"
+        echo "║  Dicton needs access to /dev/input/* for hotkey detection.  ║"
+        echo "║  Run: sudo usermod -aG input $SUDO_USER                    ║"
+        echo "║  Then log out and log back in for the change to take effect.║"
+        echo "╚══════════════════════════════════════════════════════════════╝"
+        echo ""
+    fi
+fi
+EOF
+chmod 0755 "${STAGE_DIR}/DEBIAN/postinst"
+
 deb_path="${DIST_DIR}/dicton_${version}_amd64.deb"
 echo "==> Building Debian package: ${deb_path}"
 dpkg-deb --build --root-owner-group "${STAGE_DIR}" "${deb_path}"

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.8.2"
+__version__ = "1.8.3"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/orchestration/runtime_service.py
+++ b/src/dicton/orchestration/runtime_service.py
@@ -59,17 +59,33 @@ class RuntimeService:
             )
             return self._fn_handler.start()
         except ImportError:
-            print("FN key support requires evdev: pip install dicton[fnkey]")
+            from ..shared.platform_utils import IS_WAYLAND, IS_X11, WAYLAND_COMPOSITOR
+
+            print("FN key backend: evdev not available in this build")
+            print(
+                f"   Platform: X11={IS_X11}, Wayland={IS_WAYLAND}, compositor={WAYLAND_COMPOSITOR}"
+            )
             return False
         except Exception as exc:
-            if self._app_config.debug:
-                print(f"FN handler init failed: {exc}")
+            from ..shared.platform_utils import IS_WAYLAND, IS_X11, WAYLAND_COMPOSITOR
+
+            print(f"FN handler init failed: {exc}")
+            print(
+                f"   Platform: X11={IS_X11}, Wayland={IS_WAYLAND}, compositor={WAYLAND_COMPOSITOR}"
+            )
             return False
 
     def run(self) -> None:
         print("\n" + "=" * 50)
         print("🚀 Dicton")
         print("=" * 50)
+
+        from ..shared.platform_utils import IS_WAYLAND, IS_X11, WAYLAND_COMPOSITOR
+
+        if IS_X11:
+            print("Display: X11")
+        elif IS_WAYLAND:
+            print(f"Display: Wayland ({WAYLAND_COMPOSITOR})")
 
         if self._check_vpn_active():
             print("⚠ VPN detected - API calls may fail or timeout")
@@ -95,7 +111,23 @@ class RuntimeService:
             try:
                 self._keyboard.start()
             except ImportError as exc:
-                print(f"❌ No usable hotkey backend is available.\n{exc}")
+                from ..shared.platform_utils import IS_WAYLAND, IS_X11, WAYLAND_COMPOSITOR
+
+                print("❌ No usable hotkey backend is available.")
+                print(
+                    f"   Platform: X11={IS_X11}, Wayland={IS_WAYLAND}, compositor={WAYLAND_COMPOSITOR}"
+                )
+                print(f"   Error: {exc}")
+                if IS_WAYLAND:
+                    print("\n💡 On Wayland, pynput requires XWayland.")
+                    print(
+                        "   Recommended: use HOTKEY_BASE=fn (evdev-based, works natively on Wayland)"
+                    )
+                    print("   Or log in with 'Ubuntu on Xorg' session.")
+                print("\nTry one of the following resolutions:")
+                print(" * Install evdev: pip install evdev (for FN key / custom hotkey support)")
+                print(" * Add your user to the 'input' group: sudo usermod -aG input $USER")
+                print(" * If using Wayland, ensure XWayland is running and DISPLAY is set")
                 return
 
         print(f"STT: {self._recognizer.provider_name}")


### PR DESCRIPTION
## Summary

- Bundle `evdev` and `pyudev` in PyInstaller spec so the FN key handler works in `.deb` releases
- Add `collect_dynamic_libs` for `gi` and `cairo` to fix `_gi` C extension ImportError
- Remove 8 stale hiddenimports for deleted modules (`context_detector_*`, `tray`, `stt_*`, etc.)
- Add `.deb` postinst script warning about `input` group membership for `/dev/input/*` access
- Improve runtime error messages with platform detection and Wayland-specific guidance
- Bump version to 1.8.3

## Test plan

- [x] `./scripts/check.sh` passes (266 passed, 24 skipped, 0 failed)
- [x] `uv build` produces valid wheel
- [ ] Install `.deb` on Ubuntu GNOME (Wayland) and verify hotkey detection works
- [ ] Verify postinst message displays when user not in `input` group