### PR TITLE
refactor(core): remove processing-mode env reads

### DIFF
--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/adapters/input/fn/handler.py
+++ b/src/dicton/adapters/input/fn/handler.py
@@ -16,7 +16,7 @@ import threading
 import time
 from collections.abc import Callable
 
-from ....core.processing_mode import ProcessingMode, advanced_modes_enabled
+from ....core.processing_mode import ProcessingMode
 from ....shared.platform_utils import IS_LINUX
 from .device_registry import build_device_fd_map, find_keyboard_devices
 from .parser import (
@@ -59,6 +59,7 @@ class FnKeyHandler:
         secondary_hotkey_translation: str = "none",
         hotkey_base: str = "fn",
         custom_hotkey_value: str = "alt+g",
+        enable_advanced_modes: bool = False,
     ):
         """Initialize FN key handler.
 
@@ -72,6 +73,7 @@ class FnKeyHandler:
             secondary_hotkey_translation: Secondary hotkey for translation mode.
             hotkey_base: Hotkey base type ("fn" or "custom").
             custom_hotkey_value: Custom hotkey specification (e.g. "alt+g").
+            enable_advanced_modes: Whether advanced processing modes are user-accessible.
         """
         self.on_start_recording = on_start_recording
         self.on_stop_recording = on_stop_recording
@@ -83,6 +85,7 @@ class FnKeyHandler:
         self._secondary_hotkey_translation_cfg = secondary_hotkey_translation
         self._hotkey_base = hotkey_base
         self._custom_hotkey_value_cfg = custom_hotkey_value
+        self._enable_advanced_modes = enable_advanced_modes
 
         # State machine
         self._state = HotkeyState.IDLE
@@ -158,7 +161,7 @@ class FnKeyHandler:
         self._secondary_hotkeys = build_secondary_hotkeys(
             secondary_hotkey=self._secondary_hotkey_cfg,
             secondary_hotkey_translation=self._secondary_hotkey_translation_cfg,
-            advanced_modes_enabled=advanced_modes_enabled(),
+            enable_advanced_modes=self._enable_advanced_modes,
         )
 
     def _parse_custom_hotkey(self):
@@ -653,13 +656,13 @@ class FnKeyHandler:
         - FN + Space → RAW (Yellow)
         - FN only → BASIC (Orange)
         """
-        if self._ctrl_pressed and self._shift_pressed and advanced_modes_enabled():
+        if self._ctrl_pressed and self._shift_pressed and self._enable_advanced_modes:
             return ProcessingMode.TRANSLATE_REFORMAT
         if self._ctrl_pressed:
             return ProcessingMode.TRANSLATION
-        if self._alt_pressed and advanced_modes_enabled():
+        if self._alt_pressed and self._enable_advanced_modes:
             return ProcessingMode.REFORMULATION
-        if self._space_pressed and advanced_modes_enabled():
+        if self._space_pressed and self._enable_advanced_modes:
             return ProcessingMode.RAW
         return ProcessingMode.BASIC
 

--- a/src/dicton/adapters/input/fn/parser.py
+++ b/src/dicton/adapters/input/fn/parser.py
@@ -159,7 +159,7 @@ def build_secondary_hotkeys(
     *,
     secondary_hotkey: str,
     secondary_hotkey_translation: str,
-    advanced_modes_enabled: bool,
+    enable_advanced_modes: bool,
 ) -> dict[int, ProcessingMode]:
     hotkeys: dict[int, ProcessingMode] = {}
 

--- a/src/dicton/core/processing_mode.py
+++ b/src/dicton/core/processing_mode.py
@@ -4,7 +4,6 @@ Each mode has a dedicated ring color (Flexoki palette) for visual feedback.
 See CLAUDE.md for the full color convention.
 """
 
-import os
 from dataclasses import dataclass
 from enum import Enum, auto
 
@@ -84,16 +83,11 @@ def get_mode_color(mode: ProcessingMode) -> str:
     return MODE_COLORS.get(mode, "orange")
 
 
-def advanced_modes_enabled() -> bool:
-    """Return whether advanced processing modes are exposed to the user."""
-    return os.getenv("ENABLE_ADVANCED_MODES", "false").lower() == "true"
-
-
-def is_mode_enabled(mode: ProcessingMode) -> bool:
+def is_mode_enabled(mode: ProcessingMode, enable_advanced_modes: bool) -> bool:
     """Return whether a processing mode is user-accessible."""
     if mode in {ProcessingMode.BASIC, ProcessingMode.TRANSLATION}:
         return True
-    return advanced_modes_enabled()
+    return enable_advanced_modes
 
 
 # Convenience alias kept for backward compatibility with ModeConfig.for_mode

--- a/src/dicton/orchestration/runtime_service.py
+++ b/src/dicton/orchestration/runtime_service.py
@@ -64,6 +64,7 @@ class RuntimeService:
                 secondary_hotkey_translation=self._app_config.secondary_hotkey_translation,
                 hotkey_base=self._app_config.hotkey_base,
                 custom_hotkey_value=self._app_config.custom_hotkey_value,
+                enable_advanced_modes=self._app_config.enable_advanced_modes,
             )
             return self._fn_handler.start()
         except ImportError:

--- a/src/dicton/orchestration/session_service.py
+++ b/src/dicton/orchestration/session_service.py
@@ -73,7 +73,7 @@ class SessionService:
                 return  # Previous session still processing
             self._starting = True
 
-        if not is_mode_enabled(mode):
+        if not is_mode_enabled(mode, self._app_config.enable_advanced_modes):
             mode = ProcessingMode.BASIC
 
         try:
@@ -180,7 +180,7 @@ class SessionService:
         selected_text: str | None = None,
     ) -> str | None:
         """Process transcribed text based on the current mode."""
-        if not is_mode_enabled(mode):
+        if not is_mode_enabled(mode, self._app_config.enable_advanced_modes):
             mode = ProcessingMode.BASIC
 
         if mode in (ProcessingMode.BASIC, ProcessingMode.RAW):

--- a/src/dicton/shared/processing_mode.py
+++ b/src/dicton/shared/processing_mode.py
@@ -4,7 +4,6 @@ from ..core.processing_mode import *  # noqa: F401,F403
 from ..core.processing_mode import (  # noqa: F401
     ModeConfig,
     ProcessingMode,
-    advanced_modes_enabled,
     for_mode,
     get_mode_color,
     is_mode_enabled,

--- a/tests/test_core_no_env_reads.py
+++ b/tests/test_core_no_env_reads.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+FORBIDDEN_ENV_READS = (
+    "import os",
+    "from os import",
+    "os.getenv",
+    "os.environ",
+    "os.environ[",
+)
+
+
+def test_core_modules_do_not_read_environment_directly():
+    core_dir = Path(__file__).resolve().parents[1] / "src" / "dicton" / "core"
+
+    for path in sorted(core_dir.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if path.name == "__init__.py" and not source.strip():
+            continue
+
+        for forbidden in FORBIDDEN_ENV_READS:
+            assert forbidden not in source, f"{path} contains forbidden env read: {forbidden}"

--- a/tests/test_fn_key_handler.py
+++ b/tests/test_fn_key_handler.py
@@ -43,3 +43,43 @@ def test_toggle_callbacks_are_delivered_in_order():
     finally:
         allow_start_to_finish.set()
         handler.stop()
+
+
+def test_fn_mode_detection_blocks_advanced_modes_when_disabled():
+    handler = FnKeyHandler(enable_advanced_modes=False)
+
+    try:
+        handler._alt_pressed = True
+        assert handler._detect_mode() == ProcessingMode.BASIC
+
+        handler._alt_pressed = False
+        handler._space_pressed = True
+        assert handler._detect_mode() == ProcessingMode.BASIC
+
+        handler._space_pressed = False
+        handler._ctrl_pressed = True
+        handler._shift_pressed = True
+        assert handler._detect_mode() == ProcessingMode.TRANSLATION
+    finally:
+        handler.stop()
+
+
+def test_fn_mode_detection_routes_advanced_modes_when_enabled():
+    handler = FnKeyHandler(enable_advanced_modes=True)
+
+    try:
+        handler._alt_pressed = True
+        assert handler._detect_mode() == ProcessingMode.REFORMULATION
+
+        handler._alt_pressed = False
+        handler._space_pressed = True
+        assert handler._detect_mode() == ProcessingMode.RAW
+
+        handler._space_pressed = False
+        handler._ctrl_pressed = True
+        assert handler._detect_mode() == ProcessingMode.TRANSLATION
+
+        handler._shift_pressed = True
+        assert handler._detect_mode() == ProcessingMode.TRANSLATE_REFORMAT
+    finally:
+        handler.stop()

--- a/tests/test_processing_mode.py
+++ b/tests/test_processing_mode.py
@@ -1,28 +1,17 @@
-import importlib
+from dicton.core.processing_mode import ProcessingMode, is_mode_enabled
 
 
-def test_basic_and_translation_enabled_by_default(clean_env, monkeypatch):
-    monkeypatch.delenv("ENABLE_ADVANCED_MODES", raising=False)
-
-    import dicton.shared.config as config_module
-    import dicton.shared.processing_mode as processing_mode
-
-    importlib.reload(config_module)
-    importlib.reload(processing_mode)
-
-    assert processing_mode.is_mode_enabled(processing_mode.ProcessingMode.BASIC) is True
-    assert processing_mode.is_mode_enabled(processing_mode.ProcessingMode.TRANSLATION) is True
-    assert processing_mode.is_mode_enabled(processing_mode.ProcessingMode.REFORMULATION) is False
+def test_basic_and_translation_enabled_without_advanced_modes():
+    assert is_mode_enabled(ProcessingMode.BASIC, enable_advanced_modes=False) is True
+    assert is_mode_enabled(ProcessingMode.TRANSLATION, enable_advanced_modes=False) is True
+    assert is_mode_enabled(ProcessingMode.REFORMULATION, enable_advanced_modes=False) is False
+    assert is_mode_enabled(ProcessingMode.TRANSLATE_REFORMAT, enable_advanced_modes=False) is False
+    assert is_mode_enabled(ProcessingMode.RAW, enable_advanced_modes=False) is False
 
 
-def test_advanced_modes_can_be_reenabled(clean_env, monkeypatch):
-    monkeypatch.setenv("ENABLE_ADVANCED_MODES", "true")
-
-    import dicton.shared.config as config_module
-    import dicton.shared.processing_mode as processing_mode
-
-    importlib.reload(config_module)
-    importlib.reload(processing_mode)
-
-    assert processing_mode.is_mode_enabled(processing_mode.ProcessingMode.REFORMULATION) is True
-    assert processing_mode.is_mode_enabled(processing_mode.ProcessingMode.RAW) is True
+def test_advanced_modes_can_be_enabled_explicitly():
+    assert is_mode_enabled(ProcessingMode.BASIC, enable_advanced_modes=True) is True
+    assert is_mode_enabled(ProcessingMode.TRANSLATION, enable_advanced_modes=True) is True
+    assert is_mode_enabled(ProcessingMode.REFORMULATION, enable_advanced_modes=True) is True
+    assert is_mode_enabled(ProcessingMode.TRANSLATE_REFORMAT, enable_advanced_modes=True) is True
+    assert is_mode_enabled(ProcessingMode.RAW, enable_advanced_modes=True) is True

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -39,8 +39,9 @@ class _DummyMetrics:
 
 
 class _AppConfig:
-    def __init__(self):
+    def __init__(self, *, enable_advanced_modes: bool = False):
         self.debug = True
+        self.enable_advanced_modes = enable_advanced_modes
 
 
 def test_concurrent_starts_only_launch_one_session():
@@ -69,3 +70,37 @@ def test_concurrent_starts_only_launch_one_session():
     assert len(controller.sessions) == 1
     assert controller.sessions == [ProcessingMode.BASIC]
     assert service.recording is False
+
+
+def test_start_recording_rejects_advanced_mode_when_disabled():
+    controller = _DummyController()
+    service = SessionService(
+        controller=controller,
+        text_output=None,
+        metrics=_DummyMetrics(),
+        app_config=_AppConfig(enable_advanced_modes=False),
+        visualizer_factory=lambda: None,
+    )
+
+    service.start_recording(ProcessingMode.REFORMULATION)
+    assert service._record_thread is not None
+    service._record_thread.join(timeout=1.0)
+
+    assert controller.sessions == [ProcessingMode.BASIC]
+
+
+def test_start_recording_accepts_advanced_mode_when_enabled():
+    controller = _DummyController()
+    service = SessionService(
+        controller=controller,
+        text_output=None,
+        metrics=_DummyMetrics(),
+        app_config=_AppConfig(enable_advanced_modes=True),
+        visualizer_factory=lambda: None,
+    )
+
+    service.start_recording(ProcessingMode.REFORMULATION)
+    assert service._record_thread is not None
+    service._record_thread.join(timeout=1.0)
+
+    assert controller.sessions == [ProcessingMode.REFORMULATION]


### PR DESCRIPTION
## Summary
- remove direct environment reads from core processing-mode logic
- thread advanced-mode availability through AppConfig into session and FN handling
- add architecture coverage preventing future core env reads

## Validation
- ./scripts/check.sh
- manual smoke: ENABLE_ADVANCED_MODES=false rejects REFORMULATION / FN+Alt routes BASIC
- manual smoke: ENABLE_ADVANCED_MODES=true accepts REFORMULATION / FN+Alt routes REFORMULATION

Closes #54