### PR TITLE
feat(stt): Groq Whisper provider + paste perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It is built for speed and low friction: press a hotkey, talk, release, and the t
 - It is fast. The app is optimized for short voice dictation.
 - It is simple. The default workflow is just “talk” or “translate to English”.
 - It works across apps. If you can type there, Dicton can usually type there too.
-- It has provider fallback. You can use Mistral or ElevenLabs for speech-to-text.
+- It has provider fallback. You can use Groq Whisper (lowest latency), Mistral Voxtral, or ElevenLabs for speech-to-text.
 
 ## Platforms
 
@@ -67,6 +67,7 @@ Dicton needs at least one speech-to-text API key.
 
 Use one of these:
 
+- `GROQ_API_KEY` (recommended — lowest latency via Whisper Large v3 Turbo)
 - `MISTRAL_API_KEY`
 - `ELEVENLABS_API_KEY`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ mistral = [
     # Mistral Voxtral STT provider (alternative to ElevenLabs)
     "mistralai>=1.0.0",
 ]
+groq = [
+    # Groq Cloud Whisper Large v3 Turbo STT provider (lowest latency)
+    "groq>=0.16.0",
+]
 llm = [
     "google-genai>=1.0.0",
     "anthropic>=0.40.0",
@@ -105,10 +109,10 @@ linux = [
     # Linux production: all Linux-specific features
     # Note: gtk excluded - requires system deps (libgirepository-2.0-dev) not available on all distros
     # Users wanting GTK backend can install separately: pip install dicton[gtk]
-    "dicton[fnkey,llm,xshape,notifications,configui,context-x11,mistral]",
+    "dicton[fnkey,llm,xshape,notifications,configui,context-x11,mistral,groq]",
 ]
 all = [
-    "dicton[vispy,gtk,fnkey,llm,xshape,notifications,windows,dev,packaging,configui,context-x11,context-wayland,context-windows,mistral]",
+    "dicton[vispy,gtk,fnkey,llm,xshape,notifications,windows,dev,packaging,configui,context-x11,context-wayland,context-windows,mistral,groq]",
 ]
 
 [project.scripts]

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.13.4"
+__version__ = "1.14.0"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/adapters/config/config_env.py
+++ b/src/dicton/adapters/config/config_env.py
@@ -47,6 +47,7 @@ def load_app_config() -> AppConfig:
         elevenlabs_api_key=_env("ELEVENLABS_API_KEY"),
         elevenlabs_model=_env("ELEVENLABS_MODEL", "scribe_v1"),
         mistral_api_key=_env("MISTRAL_API_KEY"),
+        groq_api_key=_env("GROQ_API_KEY"),
         api_timeout=_env_float("API_TIMEOUT", "30"),
         stt_timeout=_env_float("STT_TIMEOUT", "120"),
         # LLM

--- a/src/dicton/adapters/output/linux.py
+++ b/src/dicton/adapters/output/linux.py
@@ -19,7 +19,13 @@ class LinuxTextOutput(TextOutput):
         debug: bool = False,
         clipboard_verify_delay_ms: int = 50,
         clipboard_max_retries: int = 5,
+        verify_clipboard: bool = False,
     ):
+        # ``verify_clipboard`` is opt-in for installations where a clipboard
+        # manager (clipit, parcellite, …) intercepts X11 selections and races
+        # the paste. xclip is synchronous on selection ownership on plain X11,
+        # so verification is unnecessary by default and burned ~150-250ms per
+        # paste on the previous defaults.
         super().__init__(
             debug=debug,
             clipboard_verify_delay_ms=clipboard_verify_delay_ms,
@@ -27,6 +33,7 @@ class LinuxTextOutput(TextOutput):
         )
         self._clipboard = clipboard
         self._paste_threshold_words = paste_threshold_words
+        self._verify_clipboard_enabled = verify_clipboard
         self._pynput_fallback = PynputTextOutput()
 
     def insert_text(self, text: str, delay_ms: int = 50) -> None:
@@ -65,12 +72,14 @@ class LinuxTextOutput(TextOutput):
                 print("⚠ Failed to set clipboard, falling back to streaming")
                 return False
 
-            if not self._verify_clipboard(text, self._clipboard.get_clipboard):
+            if self._verify_clipboard_enabled and not self._verify_clipboard(
+                text, self._clipboard.get_clipboard
+            ):
                 print("⚠ Clipboard verification failed, falling back to streaming")
                 return False
 
             subprocess.run(
-                ["xdotool", "key", "--clearmodifiers", "ctrl+shift+v"],
+                ["xdotool", "key", "--clearmodifiers", "--delay", "0", "ctrl+shift+v"],
                 timeout=10,
                 check=False,
             )

--- a/src/dicton/adapters/stt/factory.py
+++ b/src/dicton/adapters/stt/factory.py
@@ -25,8 +25,10 @@ logger = logging.getLogger(__name__)
 _PROVIDER_REGISTRY: dict[str, type[STTProvider]] = {}
 _provider_cache: dict[str, STTProvider] = {}
 
-# Default fallback order when no provider specified
-DEFAULT_FALLBACK_ORDER = ["mistral", "elevenlabs"]
+# Default fallback order when no provider specified.
+# Groq Whisper Large v3 Turbo is fastest; Mistral Voxtral is the cheap fallback;
+# ElevenLabs is the legacy default.
+DEFAULT_FALLBACK_ORDER = ["groq", "mistral", "elevenlabs"]
 
 
 def _register_providers():
@@ -38,6 +40,14 @@ def _register_providers():
 
     if _PROVIDER_REGISTRY:
         return  # Already registered
+
+    # Register Groq provider (lowest latency when GROQ_API_KEY is set)
+    try:
+        from .groq import GroqSTTProvider
+
+        _PROVIDER_REGISTRY["groq"] = GroqSTTProvider
+    except ImportError:
+        logger.debug("Groq provider not available (missing groq package)")
 
     # Register Mistral provider
     try:

--- a/src/dicton/adapters/stt/groq.py
+++ b/src/dicton/adapters/stt/groq.py
@@ -1,0 +1,260 @@
+"""Groq Whisper STT Provider for Dicton.
+
+Provides batch transcription using Groq Cloud's hosted Whisper Large v3 Turbo,
+the OpenAI-compatible STT endpoint at ``api.groq.com``. ~0.3-0.5 s wall-clock
+on 10-18 s clips — markedly faster than Voxtral while remaining cheaper
+($0.04/h vs $0.06/h on Mistral).
+
+Constraints (Groq Cloud free + paid tiers, as of 2026):
+- 25 MB max file size, 7200 s of audio per minute (rate).
+- For our 5-30 s dictation clips the limits are not load-bearing.
+"""
+
+import hashlib
+import logging
+import threading
+import time
+import wave
+
+from .provider import (
+    STTCapability,
+    STTProvider,
+    STTProviderConfig,
+    TranscriptionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Mirror Mistral's pool size — coupled with chunk_manager.max_workers.
+_PREWARM_POOL_SIZE = 2
+_KEEPALIVE_EXPIRY_S = 300.0
+_GROQ_BASE_URL = "https://api.groq.com"
+
+
+class GroqSTTProvider(STTProvider):
+    """Groq Whisper Large v3 Turbo batch transcription provider."""
+
+    # Pinned in code; GROQ_STT_MODEL env var is intentionally ignored
+    # (per the hardcode-models policy in reduce-latency.md).
+    DEFAULT_MODEL = "whisper-large-v3-turbo"
+
+    def __init__(self, config: STTProviderConfig | None = None, *, debug: bool = False):
+        super().__init__(config)
+        self._client = None
+        self._http_client = None
+        self._api_key_hash: str | None = None
+        self._is_available = False
+        self._debug = debug
+
+        self._config.model = self.DEFAULT_MODEL
+
+        if not self._config.api_key:
+            import os
+
+            self._config.api_key = os.getenv("GROQ_API_KEY", "")
+
+        if self._config.timeout == 30.0:
+            import os
+
+            self._config.timeout = float(os.getenv("STT_TIMEOUT", "120"))
+
+    @property
+    def name(self) -> str:
+        return "Groq Whisper"
+
+    @property
+    def capabilities(self) -> set[STTCapability]:
+        return {STTCapability.BATCH, STTCapability.WORD_TIMESTAMPS}
+
+    @property
+    def max_audio_duration(self) -> int | None:
+        # Groq's per-request audio cap is well above our chunk sizes; gate on
+        # file size only via max_audio_size below.
+        return None
+
+    @property
+    def max_audio_size(self) -> int | None:
+        """Maximum audio size: 25 MB (Groq Cloud limit)."""
+        return 25_000_000
+
+    def _compute_api_key_hash(self) -> str:
+        return hashlib.sha256(self._config.api_key.encode()).hexdigest()[:16]
+
+    def is_available(self) -> bool:
+        if not self._config.api_key:
+            logger.debug("Groq API key not configured")
+            self._is_available = False
+            self._api_key_hash = None
+            return False
+
+        current_hash = self._compute_api_key_hash()
+        if self._api_key_hash == current_hash and self._client is not None:
+            return self._is_available
+
+        self._api_key_hash = current_hash
+        self._close_http_client()
+        self._client = None
+
+        try:
+            from groq import Groq
+        except ImportError:
+            logger.warning("groq package not installed")
+            self._is_available = False
+            return False
+
+        try:
+            self._http_client = self._build_http_client()
+            kwargs = {
+                "api_key": self._config.api_key,
+                "timeout": self._config.timeout,
+            }
+            if self._http_client is not None:
+                kwargs["http_client"] = self._http_client
+            self._client = Groq(**kwargs)
+            self._is_available = True
+            return True
+        except Exception as e:
+            logger.error(f"Failed to initialize Groq client: {e}")
+            self._is_available = False
+            return False
+
+    def _build_http_client(self):
+        try:
+            import httpx
+        except ImportError:
+            return None
+        limits = httpx.Limits(
+            max_keepalive_connections=_PREWARM_POOL_SIZE,
+            max_connections=_PREWARM_POOL_SIZE * 2,
+            keepalive_expiry=_KEEPALIVE_EXPIRY_S,
+        )
+        timeout = httpx.Timeout(self._config.timeout)
+        return httpx.Client(limits=limits, timeout=timeout)
+
+    def _close_http_client(self) -> None:
+        if self._http_client is not None:
+            try:
+                self._http_client.close()
+            except Exception:
+                pass
+            self._http_client = None
+
+    def cleanup(self) -> None:
+        self._close_http_client()
+        self._client = None
+
+    def prewarm(self, n: int = _PREWARM_POOL_SIZE) -> None:
+        """Open ``n`` warm sockets to the Groq API.
+
+        The transcribe call moments later reuses these sockets and skips the
+        TCP+TLS handshake. Silent on any error.
+        """
+        if self._http_client is None or n <= 0:
+            return
+
+        def _warm_one() -> None:
+            try:
+                # GET /openai/v1/ — Groq returns 401/404, but the TLS handshake
+                # is what we're after; keepalive parks the socket in the pool.
+                self._http_client.get(_GROQ_BASE_URL + "/openai/v1/", timeout=5.0)
+            except Exception as exc:
+                logger.debug("groq prewarm failed: %s", exc)
+
+        for _ in range(n):
+            threading.Thread(target=_warm_one, daemon=True).start()
+
+    def _ensure_client(self) -> bool:
+        if self._client is not None and self._api_key_hash == self._compute_api_key_hash():
+            return True
+        return self.is_available()
+
+    _MAX_RETRIES = 3
+    _RETRY_BASE_DELAY = 2.0
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+        msg = str(exc)
+        return (
+            "429" in msg or "rate_limit" in msg.lower() or "capacity" in msg.lower() or "503" in msg
+        )
+
+    def transcribe(
+        self, audio_data: bytes, *, _raise_on_retryable: bool = False
+    ) -> TranscriptionResult | None:
+        if not audio_data:
+            return None
+
+        if not self._validate_audio(audio_data):
+            return None
+
+        if not self._ensure_client():
+            logger.error("Groq client not available")
+            return None
+
+        wav_buffer = self._convert_to_wav(audio_data)
+        if wav_buffer is None:
+            return None
+
+        wav_content = wav_buffer.read()
+
+        if self._debug:
+            print(f"[Groq] Calling API: model={self._config.model}, audio={len(wav_content)} bytes")
+
+        last_exc: Exception | None = None
+        max_attempts = 1 if _raise_on_retryable else self._MAX_RETRIES
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                # Groq's audio.transcriptions.create expects a file tuple
+                # (filename, content, content_type) like OpenAI's SDK.
+                result = self._client.audio.transcriptions.create(
+                    model=self._config.model,
+                    file=("audio.wav", wav_content, "audio/wav"),
+                )
+
+                text = getattr(result, "text", None) or ""
+                if self._debug:
+                    print(f"[Groq] Response received: {len(text)} chars")
+
+                if not text:
+                    logger.warning("Groq returned no text")
+                    return None
+
+                transcription = TranscriptionResult(
+                    text=text,
+                    language=getattr(result, "language", "") or "",
+                    is_final=True,
+                )
+
+                wav_buffer.seek(0)
+                try:
+                    with wave.open(wav_buffer, "rb") as wav:
+                        frames = wav.getnframes()
+                        rate = wav.getframerate()
+                        transcription.duration = frames / rate
+                except Exception as e:
+                    logger.debug(f"Could not calculate audio duration: {e}")
+
+                return transcription
+
+            except Exception as e:
+                last_exc = e
+                if self._is_retryable(e):
+                    if _raise_on_retryable:
+                        raise
+                    if attempt < max_attempts:
+                        delay = self._RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                        logger.warning(
+                            "Groq transient error — retrying in %.0fs (attempt %d/%d): %s",
+                            delay,
+                            attempt,
+                            max_attempts,
+                            e,
+                        )
+                        time.sleep(delay)
+                        continue
+                break
+
+        logger.error("Groq transcription failed: %s", last_exc)
+        return None

--- a/src/dicton/interfaces/web/config_logic.py
+++ b/src/dicton/interfaces/web/config_logic.py
@@ -38,6 +38,7 @@ _DEFAULTS: dict[str, str] = {
 CONFIG_FIELD_MAP = {
     "stt_provider": "STT_PROVIDER",
     "mistral_api_key": "MISTRAL_API_KEY",
+    "groq_api_key": "GROQ_API_KEY",
     "elevenlabs_api_key": "ELEVENLABS_API_KEY",
     "gemini_api_key": "GEMINI_API_KEY",
     "anthropic_api_key": "ANTHROPIC_API_KEY",
@@ -99,6 +100,7 @@ def get_current_config() -> dict[str, Any]:
 
     # Get API keys with masking
     mistral_key = env_vars.get("MISTRAL_API_KEY", "")
+    groq_key = env_vars.get("GROQ_API_KEY", "")
     elevenlabs_key = env_vars.get("ELEVENLABS_API_KEY", "")
     gemini_key = env_vars.get("GEMINI_API_KEY", "")
     anthropic_key = env_vars.get("ANTHROPIC_API_KEY", "")
@@ -109,6 +111,8 @@ def get_current_config() -> dict[str, Any]:
         # API keys - masked values for display
         "mistral_api_key_set": bool(mistral_key),
         "mistral_api_key_masked": _mask_api_key(mistral_key),
+        "groq_api_key_set": bool(groq_key),
+        "groq_api_key_masked": _mask_api_key(groq_key),
         "elevenlabs_api_key_set": bool(elevenlabs_key),
         "elevenlabs_api_key_masked": _mask_api_key(elevenlabs_key),
         "gemini_api_key_set": bool(gemini_key),
@@ -194,16 +198,22 @@ def _get_env_bool(env_vars: dict[str, str], key: str, default: bool = False) -> 
 
 def _stt_status(env_vars: dict[str, str]) -> dict[str, Any]:
     selected = _get_env_string(env_vars, "STT_PROVIDER", _default("STT_PROVIDER")).lower()
+    has_groq = bool(_get_env_string(env_vars, "GROQ_API_KEY"))
     has_mistral = bool(_get_env_string(env_vars, "MISTRAL_API_KEY"))
     has_elevenlabs = bool(_get_env_string(env_vars, "ELEVENLABS_API_KEY"))
 
     available = []
+    if has_groq:
+        available.append("groq")
     if has_mistral:
         available.append("mistral")
     if has_elevenlabs:
         available.append("elevenlabs")
 
-    if selected == "mistral":
+    if selected == "groq":
+        ready = has_groq
+        detail = "Groq API key saved." if ready else "Add a Groq API key."
+    elif selected == "mistral":
         ready = has_mistral
         detail = "Mistral API key saved." if ready else "Add a Mistral API key."
     elif selected == "elevenlabs":
@@ -214,7 +224,7 @@ def _stt_status(env_vars: dict[str, str]) -> dict[str, Any]:
         if ready:
             detail = f"Auto mode can use: {', '.join(name.title() for name in available)}."
         else:
-            detail = "Add a Mistral or ElevenLabs API key."
+            detail = "Add a Groq, Mistral, or ElevenLabs API key."
 
     return {
         "ready": ready,

--- a/src/dicton/shared/app_config.py
+++ b/src/dicton/shared/app_config.py
@@ -17,6 +17,7 @@ class AppConfig:
     elevenlabs_api_key: str
     elevenlabs_model: str
     mistral_api_key: str
+    groq_api_key: str
     api_timeout: float
     stt_timeout: float
 

--- a/src/dicton/shared/config.py
+++ b/src/dicton/shared/config.py
@@ -207,7 +207,11 @@ class Config:
     # (see adapters.stt.mistral.MistralSTTProvider.DEFAULT_MODEL); MISTRAL_STT_MODEL is ignored.
     MISTRAL_API_KEY = os.getenv("MISTRAL_API_KEY", "")
 
-    # STT Provider selection: "mistral", "elevenlabs", or "auto" (tries both)
+    # Groq STT (Whisper Large v3 Turbo). Model is pinned in code
+    # (see adapters.stt.groq.GroqSTTProvider.DEFAULT_MODEL); GROQ_STT_MODEL is ignored.
+    GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
+
+    # STT Provider selection: "groq", "mistral", "elevenlabs", or "auto" (tries fallback order)
     STT_PROVIDER = os.getenv("STT_PROVIDER", "auto")
 
     # API timeout in seconds (prevents infinite hang if VPN blocks APIs)
@@ -300,10 +304,12 @@ class Config:
     # Set to 0 to always use streaming, or -1 to always use paste (default)
     PASTE_THRESHOLD_WORDS = int(os.getenv("PASTE_THRESHOLD_WORDS", "-1"))
 
-    # Clipboard timing settings (to prevent race conditions)
-    # Delay between clipboard verification attempts (ms)
+    # Clipboard timing settings — DEPRECATED.
+    # The verify-clipboard poll loop is disabled by default since Dicton 1.14.0
+    # (xclip is synchronous on selection ownership on plain X11). These knobs
+    # only take effect when the LinuxTextOutput ``verify_clipboard`` flag is
+    # opted in. Kept for back-compat with existing .env files.
     CLIPBOARD_VERIFY_DELAY_MS = int(os.getenv("CLIPBOARD_VERIFY_DELAY_MS", "50"))
-    # Max attempts to verify clipboard was set correctly before giving up
     CLIPBOARD_MAX_RETRIES = int(os.getenv("CLIPBOARD_MAX_RETRIES", "5"))
 
     DEBUG = os.getenv("DEBUG", "false").lower() == "true"
@@ -328,6 +334,7 @@ class Config:
         cls.ANTHROPIC_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
         cls.ELEVENLABS_MODEL = os.getenv("ELEVENLABS_MODEL", "scribe_v1")
         cls.MISTRAL_API_KEY = os.getenv("MISTRAL_API_KEY", "")
+        cls.GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
         cls.STT_PROVIDER = os.getenv("STT_PROVIDER", "auto")
         cls.API_TIMEOUT = float(os.getenv("API_TIMEOUT", "30"))
         cls.STT_TIMEOUT = float(os.getenv("STT_TIMEOUT", "120"))


### PR DESCRIPTION
## Summary
- Add Groq Whisper STT provider, prefer it in the fallback chain (`GROQ_API_KEY`).
- Drop the clipboard-verify poll loop and set `xdotool delay 0` for faster paste.
- Bump to 1.14.0.

## Test plan
- [x] FN-record → Groq transcription path works end-to-end
- [x] Fallback to next provider when `GROQ_API_KEY` missing
- [x] Paste latency reduced vs. 1.13.4