### PR TITLE
fix(stt+cleaner): kill Whisper Russian inserts, French cleaner with no-summarisation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,22 @@
 
 # Dicton
 
-Dicton is a dictation app that lets you speak directly into any text field.
+Dicton is a French-first dictation app that lets you speak directly into any text field.
 
-It is built for speed and low friction: press a hotkey, talk, release, and the text appears where your cursor already is. The default product is intentionally simple:
+It is built for speed and low friction: press a hotkey, talk in French, release, and the text appears where your cursor already is. The product is intentionally narrow:
 
-- direct transcription
-- translation to English
+- French direct transcription
+- French transcript cleanup that preserves meaning and details
+- optional translation from French to English
 - system-wide typing into the active app
 
 ## Why It Works Well
 
 - It stays out of the way. You do not have to dictate inside a separate editor first.
 - It is fast. The app is optimized for short voice dictation.
-- It is simple. The default workflow is just “talk” or “translate to English”.
+- It is simple. The default workflow is just “dictate in French” or “translate French to English”.
 - It works across apps. If you can type there, Dicton can usually type there too.
-- It has provider fallback. You can use Groq Whisper (lowest latency), Mistral Voxtral, or ElevenLabs for speech-to-text.
+- It has provider fallback. You can use Groq Whisper (lowest latency), Mistral Voxtral, or ElevenLabs for French speech-to-text.
 
 ## Platforms
 
@@ -63,7 +64,7 @@ Download `dicton-windows-x64.zip` from the latest release.
 
 ## First Setup
 
-Dicton needs at least one speech-to-text API key.
+Dicton needs at least one speech-to-text API key. Speech input is French by design; the STT providers are explicitly hinted for French to avoid language-detection drift.
 
 Use one of these:
 
@@ -71,7 +72,7 @@ Use one of these:
 - `MISTRAL_API_KEY`
 - `ELEVENLABS_API_KEY`
 
-For translation to English, add one of these too:
+For French-to-English translation, add one of these too:
 
 - `GEMINI_API_KEY`
 - `ANTHROPIC_API_KEY`
@@ -85,6 +86,7 @@ dicton --config
 That opens the guided setup page in your browser. It walks through:
 
 - speech provider key
+- French input-language confirmation
 - hotkey validation
 - first transcription test
 - start-on-login
@@ -107,12 +109,12 @@ GEMINI_API_KEY=your_key_here
 
 ### Linux default hotkeys
 
-- `FN` double-tap: start/stop recording (transcribe)
-- `FN + Ctrl`: translate to English
+- `FN` double-tap: start/stop recording (French transcription)
+- `FN + Ctrl`: translate French to English
 
 ### Windows default hotkey
 
-- `Alt+G`: start/stop dictation
+- `Alt+G`: start/stop French dictation
 
 ## Notes
 

--- a/docs/TODO-mistral-stt.md
+++ b/docs/TODO-mistral-stt.md
@@ -25,7 +25,7 @@ Follow-up work, if needed later:
 - [ ] Verify transcription accuracy on sample audio
 - [ ] Compare latency vs ElevenLabs
 - [ ] Verify cost (check Mistral dashboard usage)
-- [ ] Test with different languages (EN, FR, DE, ES)
+- [ ] Test French dictation accuracy across accents and silence/noise conditions
 
 ---
 
@@ -61,13 +61,13 @@ client = Mistral(api_key=os.getenv("MISTRAL_API_KEY"))
 result = client.audio.transcriptions.complete(
     model="voxtral-mini-latest",
     file={"content": wav_buffer, "file_name": "audio.wav"},
-    # language="en",  # Optional: boost accuracy (incompatible with timestamps)
+    language="fr",  # Required: Dicton is French-first (incompatible with timestamps)
     # timestamp_granularities=["segment"]  # Optional: get timing info
 )
 
 # Access result
 text = result.text
-language = result.language  # Detected language
+language = result.language  # Provider-reported language (expected: French)
 # segments = result.segments  # If timestamps requested
 ```
 
@@ -76,7 +76,7 @@ language = result.language  # Detected language
 1. **No streaming**: Mistral only supports batch transcription
 2. **Duration limit**: ~15 minutes max per request
 3. **Timestamp/language conflict**: Cannot use both parameters together
-4. **Languages**: Best for EN, FR, DE, ES, PT, HI, NL, IT
+4. **Language**: Dicton forces French hints; multilingual dictation is intentionally out of scope
 
 ### Cost Calculation
 
@@ -90,7 +90,7 @@ language = result.language  # Detected language
 ## Acceptance Criteria
 
 - [ ] `STT_PROVIDER=mistral` enables Mistral transcription
-- [ ] Transcription accuracy comparable to ElevenLabs on major languages
+- [ ] French transcription accuracy comparable to ElevenLabs
 - [ ] Fallback to next provider on Mistral API errors
 - [ ] Configuration visible in dashboard
 - [ ] API key securely stored in `.env`

--- a/docs/feature/clean_llm_process.md
+++ b/docs/feature/clean_llm_process.md
@@ -12,7 +12,7 @@ Insert a **mandatory, low-latency LLM cleanup pass** between STT (Mistral Voxtra
 - Removes filler words / hesitations (`euh`, `um`, `genre`, `du coup`, …).
 - Strips bracketed/parenthesised non-speech annotations the STT may emit (`[bruit]`, `(rires)`, `[music]`, `[silence]`, `[inaudible]`, …).
 - Reconstructs the utterance with **faithful** lexical content but **correct grammar and syntax**.
-- Preserves the speaker's voice, tone, register, and language — does **not** translate, summarise, or reformulate.
+- Preserves the speaker's voice, tone, register, and French language — does **not** translate, summarise, or reformulate.
 
 Model: **Gemini 3.1 Flash-Lite Preview** — picked from the 2026-05-04 Artificial Analysis leaderboard for its 356 tokens/s throughput and II 34, the best speed/intel ratio at sub-cent cost. Fallback to `gemini-2.5-flash-lite` if the preview alias fails.
 
@@ -162,12 +162,12 @@ Trim `prompts.py::reformulate` and `translate` prompts: drop the explicit filler
 You are a transcript cleaner. The input is raw speech-to-text output.
 
 YOUR JOB:
-- Remove filler words and hesitation sounds in any language
-  (euh, heu, um, uh, like, you know, en fait, du coup, voilà, genre, bah, ben, hein, …).
+- Remove French filler words and hesitation sounds
+  (euh, heu, en fait, du coup, voilà, genre, bah, ben, hein, tu vois, …).
 - Remove ALL bracketed or parenthesised non-speech annotations the STT may have
   emitted: [bruit], [noise], [music], [silence], [inaudible], (rires), (laughs), …
 - Repair grammar and syntax so the output is a well-formed sentence (or several),
-  in the SAME language as the input.
+  in French.
 - Preserve faithfully WHAT was said: do not paraphrase, do not summarise, do not
   add ideas, do not change the tone or register, do not translate.
 - Keep proper nouns, technical terms, code identifiers verbatim.
@@ -230,7 +230,7 @@ Each commit must pass `./scripts/check.sh` (full, not just lint).
 ## 9. Out of scope (for this feature)
 
 - A local model (whisper-style refiner running on-device).
-- Per-language cleaner prompt variants.
+- Future non-French support would require explicit product/API redesign; the cleaner is French-specific by design.
 - Adaptive cleaner intensity (heavy/light).
 - Streaming cleaner that runs on partial STT chunks.
 

--- a/docs/windows-packaging.md
+++ b/docs/windows-packaging.md
@@ -7,8 +7,8 @@ This project now includes a first Windows packaging path based on PyInstaller.
 The Windows bundle is intended for the fallback desktop workflow:
 
 - `Alt+G` hotkey mode
-- Basic transcription
-- Translation to English
+- French basic transcription
+- French-to-English translation
 - Config UI via `dicton.exe --config-ui`
 - Experimental Windows context detection
 

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "1.14.1"
 __author__ = "asi0 flammeus"
-__description__ = "Voice-to-text dictation with direct transcription and translation"
+__description__ = "French voice-to-text dictation with direct transcription and English translation"
 
 __all__ = ["main", "__version__"]
 

--- a/src/dicton/adapters/config/config_env.py
+++ b/src/dicton/adapters/config/config_env.py
@@ -41,7 +41,7 @@ def load_app_config() -> AppConfig:
         # General
         debug=_env_bool("DEBUG", "false"),
         notifications_enabled=_env_bool("NOTIFICATIONS_ENABLED", "false"),
-        language=_env("LANGUAGE", "auto"),
+        language=_env("LANGUAGE", "fr"),
         # STT
         stt_provider=_env("STT_PROVIDER", "auto"),
         elevenlabs_api_key=_env("ELEVENLABS_API_KEY"),

--- a/src/dicton/adapters/llm/cleaner.py
+++ b/src/dicton/adapters/llm/cleaner.py
@@ -31,17 +31,19 @@ _DEFAULT_CLEANER_MODELS: dict[str, str] = {
 }
 
 
-_CLEANER_PROMPT_TEMPLATE = """Clean this speech-to-text transcript. Output ONLY the cleaned text.
+_CLEANER_PROMPT_TEMPLATE = """Nettoie cette transcription speech-to-text. Renvoie UNIQUEMENT le texte nettoyé, sans préambule ni guillemets.
 
-Rules:
-- Same language as input. Never translate.
-- Remove filler words (euh, um, like, du coup, genre, …) and bracketed
-  STT annotations ([bruit], [music], (rires), …).
-- Fix grammar/syntax. Keep meaning, tone, proper nouns, technical terms.
-- Light punctuation only.
-- If empty or meaningless: output exactly None.
+Règles strictes :
+- L'entrée est en français. Garde le français en sortie. Ne traduis jamais.
+- Conserve les anglicismes tels que dictés (workflow, commit, scope, deadline, …) — ne les francise pas.
+- Conserve le tutoiement OU le vouvoiement déjà présent dans la dictée selon le contexte de chaque phrase ; ne bascule jamais l'un en l'autre.
+- Ne résume pas, ne raccourcis pas, ne synthétise pas. Tous les exemples, détails, énumérations, digressions et précisions doivent être préservés intégralement. Tu n'as PAS le droit d'omettre une idée, un exemple ou un détail au prétexte qu'il serait redondant ou accessoire.
+- Tu peux uniquement corriger la FORME : ponctuation légère, accords manqués, conjugaison, mots collés/coupés par le STT, syntaxe cassée par l'oral. Le fond reste mot pour mot.
+- Retire les tics de langage (« euh », « heu », « du coup », « genre », « tu vois », « en fait » quand purement de remplissage) et les annotations laissées par le STT entre crochets ou parenthèses ([bruit], [musique], (rires), …).
+- Corrections orthographiques dictées : si la dictée contient une consigne du type « X avec un Y », « X s'écrit Y », « X plutôt avec deux L », applique-la directement sur l'occurrence concernée (précédente, ou suivante si la consigne précède le mot) et n'écris PAS la consigne dans la sortie. Exemple : « alisis avec un y » → remplace « alisis » par « alysis » et supprime la consigne.
+- Si l'entrée est vide ou n'a aucun sens : renvoie exactement None.
 
-INPUT:
+ENTRÉE :
 {text}"""
 
 

--- a/src/dicton/adapters/llm/prompts.py
+++ b/src/dicton/adapters/llm/prompts.py
@@ -51,7 +51,7 @@ def reformulate(
 
     Args:
         text: The transcribed text to reformulate.
-        language: Optional language code (e.g., 'en', 'fr') to ensure output matches.
+        language: Legacy language code. Reformulation is French-first; the value is informational only.
         user_provider: Preferred LLM provider name.
         debug: Enable debug output.
 
@@ -61,36 +61,33 @@ def reformulate(
     if not text:
         return None
 
-    language_instruction = ""
-    if language:
-        language_instruction = f"The text is in {language}. Keep your output in the same language."
+    language_instruction = "The text is French. Keep your output in French."
 
     prompt = f"""You are a structural text reformulator. The input has already been
 cleaned of filler words and STT artefacts upstream — focus on structure, not
 filler removal.
 
 RULES:
-1. OUTPUT MUST BE IN THE SAME LANGUAGE as the input. DO NOT translate.
+1. OUTPUT MUST BE IN FRENCH. DO NOT translate.
 2. Preserve the speaker's voice, tone, and meaning. Keep changes minimal.
-3. Convert spoken numbers to digits (e.g., "twenty-three" → "23",
-   "vingt-trois" → "23").
+3. Convert spoken numbers to digits (e.g., "vingt-trois" → "23").
 4. Format enumerated items as lists when the speaker introduces points
    sequentially. Use numbered lists (1. 2. 3.) when speaker uses ordinals
-   like "first", "second", "premier", "deuxième"; bullet points otherwise.
+   like "premier", "deuxième"; bullet points otherwise.
 5. Interpret dictation commands and replace them with actual punctuation:
-   - "new line" / "à la ligne" → line break
-   - "new paragraph" / "nouveau paragraphe" → double line break
-   - "dash" / "tiret" → "-"
-   - "open parenthesis" / "ouvrir parenthèse" → "("
-   - "close parenthesis" / "fermer parenthèse" → ")"
-   - "open bracket" / "ouvrir crochet" → "["
-   - "close bracket" / "fermer crochet" → "]"
-   - "colon" / "deux points" → ":"
-   - "semicolon" / "point virgule" → ";"
-   - "comma" / "virgule" → ","
-   - "period" / "point final" → "."
-   - "question mark" / "point d'interrogation" → "?"
-   - "exclamation mark" / "point d'exclamation" → "!"
+   - "à la ligne" → line break
+   - "nouveau paragraphe" → double line break
+   - "tiret" → "-"
+   - "ouvrir parenthèse" → "("
+   - "fermer parenthèse" → ")"
+   - "ouvrir crochet" → "["
+   - "fermer crochet" → "]"
+   - "deux points" → ":"
+   - "point virgule" → ";"
+   - "virgule" → ","
+   - "point final" → "."
+   - "point d'interrogation" → "?"
+   - "point d'exclamation" → "!"
 6. If the input is empty or has no meaningful content, output exactly "None".
 7. Return ONLY the reformulated text, no explanations.
 {language_instruction}

--- a/src/dicton/adapters/stt/elevenlabs.py
+++ b/src/dicton/adapters/stt/elevenlabs.py
@@ -6,7 +6,7 @@ High-accuracy transcription with word-level timestamps.
 Key features:
 - Batch-only (no streaming)
 - Word-level timestamps
-- Auto language detection
+- French language hint
 """
 
 import hashlib
@@ -31,8 +31,8 @@ class ElevenLabsSTTProvider(STTProvider):
     Features:
     - Batch transcription via REST API
     - Word-level timestamps
-    - Auto language detection
-    - High accuracy for multiple languages
+    - French language hint
+    - High accuracy French fallback
     """
 
     DEFAULT_MODEL = "scribe_v1"
@@ -159,10 +159,11 @@ class ElevenLabsSTTProvider(STTProvider):
             return None
 
         try:
-            # Call ElevenLabs STT API (language_code=None for auto-detect)
+            # French is the product language. ElevenLabs expects ISO-639-3 here.
             result = self._client.speech_to_text.convert(
                 file=wav_buffer,
                 model_id=self._config.model,
+                language_code="fra",
             )
 
             if not result or not hasattr(result, "text"):

--- a/src/dicton/adapters/stt/groq.py
+++ b/src/dicton/adapters/stt/groq.py
@@ -208,9 +208,14 @@ class GroqSTTProvider(STTProvider):
             try:
                 # Groq's audio.transcriptions.create expects a file tuple
                 # (filename, content, content_type) like OpenAI's SDK.
+                # language="fr" est imposé : sans hint, Whisper Large v3 Turbo
+                # hallucine régulièrement des inserts russes en début de
+                # transcription (silence/respiration/clic) — séquelle bien connue
+                # du corpus YouTube auto-translated subs.
                 result = self._client.audio.transcriptions.create(
                     model=self._config.model,
                     file=("audio.wav", wav_content, "audio/wav"),
+                    language="fr",
                 )
 
                 text = getattr(result, "text", None) or ""

--- a/src/dicton/adapters/stt/mistral.py
+++ b/src/dicton/adapters/stt/mistral.py
@@ -263,10 +263,14 @@ class MistralSTTProvider(STTProvider):
         for attempt in range(1, max_attempts + 1):
             try:
                 # Call Mistral API
-                # Note: Cannot use language + timestamp_granularities together
+                # Note: Cannot use language + timestamp_granularities together —
+                # we ne demandons pas les timestamps ici, donc le hint langue
+                # est sûr et évite les dérives de détection sur le silence
+                # initial (cf. fix Groq pour la même raison).
                 result = self._client.audio.transcriptions.complete(
                     model=self._config.model,
                     file={"content": wav_content, "file_name": "audio.wav"},
+                    language="fr",
                 )
 
                 if self._debug:

--- a/src/dicton/adapters/stt/mistral.py
+++ b/src/dicton/adapters/stt/mistral.py
@@ -6,7 +6,7 @@ Offers 85% cost savings vs ElevenLabs with comparable accuracy.
 Key constraints:
 - Batch-only (no streaming)
 - ~15 minute max duration per request
-- Cannot use language hint + timestamps together
+- French language hint is forced; cannot use language hint + timestamps together
 """
 
 import hashlib
@@ -41,7 +41,7 @@ class MistralSTTProvider(STTProvider):
     Features:
     - Batch transcription via REST API
     - Word-level timestamps (when not using language hint)
-    - Auto language detection
+    - French-first transcription via explicit language hint
     - ~20x real-time processing speed
 
     Costs ~$0.001/min ($0.06/hr) vs $0.40/hr for ElevenLabs.

--- a/src/dicton/adapters/text/processor.py
+++ b/src/dicton/adapters/text/processor.py
@@ -7,41 +7,9 @@ from pathlib import Path
 
 from ...shared.app_paths import get_user_dictionary_path
 
-# Language-aware filler words
+# Filler words. Dicton's product language is French; English/common entries stay
+# only to strip common STT artefacts and legacy dictations.
 FILLER_WORDS = {
-    # English fillers
-    "en": {
-        "um",
-        "uh",
-        "uhm",
-        "umm",
-        "er",
-        "err",
-        "ah",
-        "ahh",
-        "eh",
-        "hmm",
-        "hm",
-        "mm",
-        "mmm",
-        "mhm",
-        "uh-huh",
-        "uh huh",
-        "like",
-        "you know",
-        "i mean",
-        "sort of",
-        "kind of",
-        "basically",
-        "actually",
-        "literally",
-        "honestly",
-        "so",
-        "well",
-        "right",
-        "okay so",
-        "yeah so",
-    },
     # French fillers
     "fr": {
         "euh",
@@ -61,42 +29,7 @@ FILLER_WORDS = {
         "tu vois",
         "tu sais",
     },
-    # German fillers
-    "de": {
-        "äh",
-        "ähm",
-        "öh",
-        "öhm",
-        "hm",
-        "hmm",
-        "also",
-        "halt",
-        "quasi",
-        "sozusagen",
-        "irgendwie",
-        "eigentlich",
-        "ja",
-        "ne",
-        "na ja",
-    },
-    # Spanish fillers
-    "es": {
-        "eh",
-        "em",
-        "este",
-        "esto",
-        "bueno",
-        "pues",
-        "o sea",
-        "es que",
-        "tipo",
-        "como que",
-        "vale",
-        "sabes",
-        "mira",
-        "entonces",
-    },
-    # Common (language-agnostic)
+    # Common STT artefacts still seen in French dictation outputs
     "common": {
         "um",
         "uh",
@@ -120,7 +53,7 @@ class TextProcessor:
         self,
         dictionary_path: Path | str | None = None,
         filter_fillers: bool = True,
-        language: str = "auto",
+        language: str = "fr",
         similarity_threshold: float | None = None,
     ):
         """Initialize the text processor.
@@ -129,8 +62,8 @@ class TextProcessor:
             dictionary_path: Path to custom dictionary JSON file.
                             If None, uses the platform-native user config location.
             filter_fillers: If True, remove filler words from transcriptions.
-            language: Language code for filler detection ('en', 'fr', 'de', 'es', 'auto').
-                     'auto' uses common fillers across all languages.
+            language: Legacy language code for filler detection. French is the
+                      product default; 'auto' is treated as French for backwards compatibility.
             similarity_threshold: Minimum similarity ratio (0.0-1.0) for fuzzy matching.
                                  If None, uses default (0.75).
         """
@@ -239,14 +172,9 @@ class TextProcessor:
         # Get filler words based on language setting
         fillers: set[str] = set()
 
-        if self.language == "auto":
-            # Use common fillers that work across languages
-            fillers = FILLER_WORDS.get("common", set()).copy()
-        else:
-            # Use language-specific fillers
-            fillers = FILLER_WORDS.get(self.language, set()).copy()
-            # Also include common fillers
-            fillers.update(FILLER_WORDS.get("common", set()))
+        language = "fr" if self.language == "auto" else self.language
+        fillers = FILLER_WORDS.get(language, set()).copy()
+        fillers.update(FILLER_WORDS.get("common", set()))
 
         # Sort by length (longest first) to match multi-word fillers before single words
         sorted_fillers = sorted(fillers, key=len, reverse=True)

--- a/src/dicton/assets/config_ui.html
+++ b/src/dicton/assets/config_ui.html
@@ -641,7 +641,7 @@
                         <option value="gemini">Gemini (default)</option>
                         <option value="anthropic">Anthropic</option>
                     </select>
-                    <div class="hint">Primary provider for reformulation and translation</div>
+                    <div class="hint">Primary provider for French reformulation and English translation</div>
                 </div>
             </div>
 
@@ -738,22 +738,11 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label>Language</label>
+                    <label>Input Language</label>
                     <select id="language">
-                        <option value="auto">Auto-detect</option>
-                        <option value="en">English</option>
                         <option value="fr">French</option>
-                        <option value="de">German</option>
-                        <option value="es">Spanish</option>
-                        <option value="it">Italian</option>
-                        <option value="pt">Portuguese</option>
-                        <option value="nl">Dutch</option>
-                        <option value="pl">Polish</option>
-                        <option value="ru">Russian</option>
-                        <option value="ja">Japanese</option>
-                        <option value="zh">Chinese</option>
-                        <option value="ko">Korean</option>
                     </select>
+                    <div class="hint">Dicton is French-first: STT providers and transcript cleaning are explicitly hinted for French.</div>
                 </div>
             </div>
 
@@ -764,7 +753,7 @@
                         <input type="checkbox" id="enable_transcript_cleaning">
                         <label class="checkbox-label">Enable LLM transcript cleaner</label>
                     </div>
-                    <div class="hint">Runs a low-latency LLM pass before mode processing to remove filler words and STT bracket annotations. Fail-open: keeps raw STT if the cleaner is unreachable.</div>
+                    <div class="hint">Runs a low-latency French LLM pass before mode processing to remove filler words and STT bracket annotations. Fail-open: keeps raw STT if the cleaner is unreachable.</div>
                 </div>
                 <div class="grid-2">
                     <div class="form-group">
@@ -1380,7 +1369,7 @@
             document.getElementById('hotkey_double_tap_window_ms').value = cfg.hotkey_double_tap_window_ms || '300';
             document.getElementById('filter_fillers').checked = cfg.filter_fillers !== false;
             document.getElementById('enable_reformulation').checked = cfg.enable_reformulation !== false;
-            document.getElementById('language').value = cfg.language || 'auto';
+            document.getElementById('language').value = 'fr';
             document.getElementById('debug').checked = cfg.debug === true;
 
             document.getElementById('mute_playback_on_recording').checked = cfg.mute_playback_on_recording !== false;
@@ -1419,7 +1408,7 @@
                 hotkey_double_tap_window_ms: document.getElementById('hotkey_double_tap_window_ms').value,
                 filter_fillers: document.getElementById('filter_fillers').checked,
                 enable_reformulation: document.getElementById('enable_reformulation').checked,
-                language: document.getElementById('language').value,
+                language: 'fr',
                 debug: document.getElementById('debug').checked,
                 mute_playback_on_recording: document.getElementById('mute_playback_on_recording').checked,
                 playback_mute_strategy: document.getElementById('playback_mute_strategy').value,

--- a/src/dicton/assets/setup_ui.html
+++ b/src/dicton/assets/setup_ui.html
@@ -410,14 +410,11 @@
                         </select>
                     </div>
                     <div class="field">
-                        <label for="language">Language</label>
+                        <label for="language">Input language</label>
                         <select id="language">
-                            <option value="auto">Auto detect</option>
-                            <option value="en">English</option>
                             <option value="fr">French</option>
-                            <option value="es">Spanish</option>
-                            <option value="de">German</option>
                         </select>
+                        <span class="muted">Dicton is French-first: STT and transcript cleaning are explicitly hinted for French.</span>
                     </div>
                     <div class="field">
                         <label for="mistral_api_key">Mistral API key</label>
@@ -446,7 +443,7 @@
                         </select>
                     </div>
                     <div class="field" style="align-self: end;">
-                        <span class="muted">Used for translation and reformulation modes.</span>
+                        <span class="muted">Used for English translation and French reformulation modes.</span>
                     </div>
                     <div class="field">
                         <label for="gemini_api_key">Gemini API key</label>
@@ -801,7 +798,7 @@
         function populateConfig() {
             const config = state.config;
             document.getElementById('stt_provider').value = config.stt_provider || 'auto';
-            document.getElementById('language').value = config.language || 'auto';
+            document.getElementById('language').value = 'fr';
             document.getElementById('llm_provider').value = config.llm_provider || 'gemini';
             document.getElementById('hotkey_base').value = config.hotkey_base || 'fn';
             renderHotkeyValue(document.getElementById('custom_hotkey_capture'), config.custom_hotkey_value || '');
@@ -824,7 +821,7 @@
         function buildPayload() {
             const payload = {
                 stt_provider: document.getElementById('stt_provider').value,
-                language: document.getElementById('language').value,
+                language: 'fr',
                 llm_provider: document.getElementById('llm_provider').value,
                 hotkey_base: document.getElementById('hotkey_base').value,
                 custom_hotkey_value: document.getElementById('custom_hotkey_capture').dataset.value || '',

--- a/src/dicton/interfaces/web/config_logic.py
+++ b/src/dicton/interfaces/web/config_logic.py
@@ -27,7 +27,7 @@ _DEFAULTS: dict[str, str] = {
     "VISUALIZER_BACKEND": "pygame",
     "HOTKEY_BASE": "fn",
     "HOTKEY_DOUBLE_TAP_WINDOW_MS": "300",
-    "LANGUAGE": "auto",
+    "LANGUAGE": "fr",
     "CUSTOM_HOTKEY_VALUE": "alt+g",
     "SECONDARY_HOTKEY": "none",
     "SECONDARY_HOTKEY_TRANSLATION": "none",

--- a/src/dicton/shared/config.py
+++ b/src/dicton/shared/config.py
@@ -289,8 +289,10 @@ class Config:
     # Set to device index number to force specific mic, or "auto"
     MIC_DEVICE = os.getenv("MIC_DEVICE", "auto")
 
-    # Language: "auto" (None), "en", "fr", etc. (ISO-639-1 or ISO-639-3)
-    LANGUAGE = os.getenv("LANGUAGE", "auto")
+    # Input language is intentionally French-only. LANGUAGE remains as a
+    # compatibility knob for existing .env files, but product paths force French
+    # STT hints and the transcript cleaner prompt is French-specific.
+    LANGUAGE = os.getenv("LANGUAGE", "fr")
 
     # Filler word filtering: "true" to enable removal of filler words (um, uh, like, etc.)
     FILTER_FILLERS = os.getenv("FILTER_FILLERS", "true").lower() == "true"
@@ -363,7 +365,7 @@ class Config:
         cls.MUTE_BACKEND = os.getenv("MUTE_BACKEND", "auto").lower()
         cls.PLAYBACK_MUTE_STRATEGY = os.getenv("PLAYBACK_MUTE_STRATEGY", "auto").lower()
         cls.MIC_DEVICE = os.getenv("MIC_DEVICE", "auto")
-        cls.LANGUAGE = os.getenv("LANGUAGE", "auto")
+        cls.LANGUAGE = os.getenv("LANGUAGE", "fr")
         cls.FILTER_FILLERS = os.getenv("FILTER_FILLERS", "true").lower() == "true"
         cls.ENABLE_REFORMULATION = os.getenv("ENABLE_REFORMULATION", "false").lower() == "true"
         cls.PASTE_THRESHOLD_WORDS = int(os.getenv("PASTE_THRESHOLD_WORDS", "-1"))

--- a/tests/test_stt_elevenlabs.py
+++ b/tests/test_stt_elevenlabs.py
@@ -148,6 +148,7 @@ class TestElevenLabsTranscription:
         assert result.language == "en"
         assert result.is_final is True
         mock_client.speech_to_text.convert.assert_called_once()
+        assert mock_client.speech_to_text.convert.call_args.kwargs["language_code"] == "fra"
 
     def test_transcribe_handles_api_error(self, mock_provider):
         """Test transcribe handles API errors gracefully."""
@@ -176,8 +177,9 @@ class TestElevenLabsTranscription:
         assert result is not None
         assert result.text == "Test"
 
-        # Verify API was called
+        # Verify API was called with the French language hint
         mock_client.speech_to_text.convert.assert_called_once()
+        assert mock_client.speech_to_text.convert.call_args.kwargs["language_code"] == "fra"
 
     def test_transcribe_with_word_timestamps(self, mock_provider):
         """Test transcription extracts word timestamps."""

--- a/tests/test_stt_groq.py
+++ b/tests/test_stt_groq.py
@@ -1,0 +1,45 @@
+"""Tests for Groq STT Provider."""
+
+from __future__ import annotations
+
+import io
+import wave
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from dicton.adapters.stt.groq import GroqSTTProvider
+from dicton.adapters.stt.provider import STTProviderConfig
+
+
+def create_test_wav(duration: float = 0.1, sample_rate: int = 16000) -> bytes:
+    """Create a small valid WAV file for transcription tests."""
+    samples = int(duration * sample_rate)
+    audio_data = np.zeros(samples, dtype=np.int16)
+
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(audio_data.tobytes())
+    return buffer.getvalue()
+
+
+def test_transcribe_sends_french_language_hint():
+    provider = GroqSTTProvider(STTProviderConfig(api_key="test_key"))
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = "Bonjour le monde"
+    mock_response.language = "fr"
+    mock_client.audio.transcriptions.create.return_value = mock_response
+    provider._client = mock_client
+    provider._is_available = True
+    provider._ensure_client = lambda: True  # type: ignore[method-assign]
+
+    result = provider.transcribe(create_test_wav())
+
+    assert result is not None
+    assert result.text == "Bonjour le monde"
+    mock_client.audio.transcriptions.create.assert_called_once()
+    assert mock_client.audio.transcriptions.create.call_args.kwargs["language"] == "fr"

--- a/tests/test_stt_mistral.py
+++ b/tests/test_stt_mistral.py
@@ -171,6 +171,7 @@ class TestMistralTranscription:
         assert result.language == "en"
         assert result.is_final is True
         mock_client.audio.transcriptions.complete.assert_called_once()
+        assert mock_client.audio.transcriptions.complete.call_args.kwargs["language"] == "fr"
 
     def test_transcribe_handles_api_error(self, mock_provider):
         """Test transcribe handles API errors gracefully."""
@@ -203,6 +204,7 @@ class TestMistralTranscription:
         call_args = mock_client.audio.transcriptions.complete.call_args
         file_arg = call_args.kwargs.get("file", call_args.args[0] if call_args.args else None)
         assert file_arg is not None
+        assert call_args.kwargs["language"] == "fr"
 
     def test_transcribe_with_word_timestamps(self, mock_provider):
         """Test transcription extracts word timestamps."""

--- a/tests/test_transcript_cleaner.py
+++ b/tests/test_transcript_cleaner.py
@@ -101,13 +101,22 @@ def test_prompt_embeds_critical_rules(patch_providers):
     providers = patch_providers({"gemini": _FakeProvider(result="ok")})
     clean_transcript("hello [bruit] world", language="fr")
     prompt, _model = providers["gemini"].calls[0]
+    lower = prompt.lower()
     # bracket-stripping rule
-    assert "[bruit]" in prompt or "bracketed" in prompt.lower()
-    # filler-removal rule
-    assert "filler" in prompt.lower()
-    # language-preservation rule (the headline rule of the cleaner)
-    assert "same language" in prompt.lower()
-    assert "never translate" in prompt.lower()
+    assert "[bruit]" in prompt
+    # filler-removal rule (mention « tics de langage »)
+    assert "tics de langage" in lower
+    # language is hardcoded to French; never translate
+    assert "français" in lower
+    assert "ne traduis jamais" in lower
+    # no-summarisation rule (flagship: dictée must be transcribed in full)
+    assert "ne résume pas" in lower or "résume pas" in lower
+    # anglicism preservation
+    assert "anglicismes" in lower
+    # tu/vous preservation
+    assert "tutoiement" in lower and "vouvoiement" in lower
+    # inline orthographic correction rule (the « alysis avec un y » case)
+    assert "avec un y" in lower or "s'écrit" in lower
 
 
 def test_default_model_for_primary_provider_is_provider_specific(patch_providers):

--- a/tests/test_transcript_cleaner.py
+++ b/tests/test_transcript_cleaner.py
@@ -165,7 +165,6 @@ def test_auto_provider_ignores_model_override(patch_providers):
 
 
 def test_build_prompt_is_stable_regardless_of_language_arg():
-    """The prompt is intentionally language-agnostic — the 'same language as
-    input' rule does the work, so the optional language arg is a no-op."""
-    assert _build_prompt("hello", language="French") == _build_prompt("hello", language="auto")
-    assert _build_prompt("hello", language=None) == _build_prompt("hello", language="fr")
+    """The cleaner is intentionally French-specific; the legacy language arg is a no-op."""
+    assert _build_prompt("bonjour", language="French") == _build_prompt("bonjour", language="auto")
+    assert _build_prompt("bonjour", language=None) == _build_prompt("bonjour", language="fr")

--- a/uv.lock
+++ b/uv.lock
@@ -467,6 +467,7 @@ all = [
     { name = "evdev" },
     { name = "fastapi" },
     { name = "google-genai" },
+    { name = "groq" },
     { name = "mistralai" },
     { name = "plyer" },
     { name = "psutil" },
@@ -510,6 +511,9 @@ fnkey = [
     { name = "evdev" },
     { name = "pyudev" },
 ]
+groq = [
+    { name = "groq" },
+]
 gtk = [
     { name = "pygobject" },
 ]
@@ -518,6 +522,7 @@ linux = [
     { name = "evdev" },
     { name = "fastapi" },
     { name = "google-genai" },
+    { name = "groq" },
     { name = "mistralai" },
     { name = "plyer" },
     { name = "psutil" },
@@ -569,6 +574,9 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "google-genai", marker = "extra == 'linux'", specifier = ">=1.0.0" },
     { name = "google-genai", marker = "extra == 'llm'", specifier = ">=1.0.0" },
+    { name = "groq", marker = "extra == 'all'", specifier = ">=0.16.0" },
+    { name = "groq", marker = "extra == 'groq'", specifier = ">=0.16.0" },
+    { name = "groq", marker = "extra == 'linux'", specifier = ">=0.16.0" },
     { name = "mistralai", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "mistralai", marker = "extra == 'linux'", specifier = ">=1.0.0" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.0.0" },
@@ -616,7 +624,7 @@ requires-dist = [
     { name = "vispy", marker = "extra == 'all'", specifier = ">=0.14.0" },
     { name = "vispy", marker = "extra == 'vispy'", specifier = ">=0.14.0" },
 ]
-provides-extras = ["all", "configui", "context-wayland", "context-windows", "context-x11", "dev", "fnkey", "gtk", "linux", "llm", "mistral", "notifications", "packaging", "vispy", "windows", "xshape"]
+provides-extras = ["all", "configui", "context-wayland", "context-windows", "context-x11", "dev", "fnkey", "groq", "gtk", "linux", "llm", "mistral", "notifications", "packaging", "vispy", "windows", "xshape"]
 
 [[package]]
 name = "distro"
@@ -760,6 +768,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/99/96/a0205167fa0154f4a542fd6925bdc63d039d88dab3588b875078107e6f06/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a", size = 147323, upload-time = "2026-03-06T21:53:09.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/28/23eea8acd65972bbfe295ce3666b28ac510dfcb115fac089d3edb0feb00a/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8", size = 297578, upload-time = "2026-03-06T21:52:33.933Z" },
+]
+
+[[package]]
+name = "groq"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/51/4728c13611849ff6cf8536740ae78ba3ee5e665d67b572a47c9ead0f9788/groq-1.2.0.tar.gz", hash = "sha256:85459e27c9c17f22404349c785cd08680362cfe85e07cc060be46c4832f108c3", size = 155609, upload-time = "2026-04-18T10:43:50.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/748639c95c60ad8846c65b167ca611c815d06d5f67a9e73b23486dce4fdf/groq-1.2.0-py3-none-any.whl", hash = "sha256:1002060a743b27c8f86765e1bc9749c98498e961d9fe2e4902bf7804a71c3c84", size = 142334, upload-time = "2026-04-18T10:43:49.125Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pins `language=\"fr\"` on Groq + Mistral STT calls. Suppresses the Whisper Large v3 Turbo Russian-subtitle hallucinations (`Продолжение следует...`) that started appearing in ~40% of dictations after the Groq adoption merge — Whisper was auto-detecting language on silent opening frames and falling back to its trained Russian YouTube-subs filler.
- Rewrites the transcript-cleaner prompt in French (dictation is now assumed always French). New behavioural rules:
  - **Preserve anglicisms** as dictated (`workflow`, `commit`, `scope`…), no francisation.
  - **Preserve tu/vous** based on context, no bascule.
  - **Forbid summarisation** — every example, detail, énumération, digression must survive. Cleaner can only touch form. Fixes drift where Gemini was condensing long dictations.
  - **Inline orthographic corrections** — a dictated rule like \"alisis avec un y\" is applied to the prior occurrence and the consigne is dropped from the output (instead of being transcribed verbatim).
- Bumps version to 1.14.1.

## Test plan

- [x] `./scripts/check.sh lint` — clean.
- [x] `pytest tests/` — 274 passed, 24 skipped.
- [x] `tests/test_transcript_cleaner.py::test_prompt_embeds_critical_rules` updated to lock in the new French keywords (`anglicismes`, `tutoiement`/`vouvoiement`, `ne résume pas`, `avec un y`).
- [ ] Manual: trigger ~10 dictations starting with brief silence; verify zero Russian inserts.
- [ ] Manual: dictate a long passage with several examples; verify cleaner doesn't summarise.
- [ ] Manual: dictate \"alisis avec un y\" mid-sentence; verify prompt rewrites to \"alysis\" and drops the consigne.