### PR TITLE
refactor(output): paste only, drop PASTE_THRESHOLD_WORDS knob

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,8 +157,8 @@ ENABLE_ADVANCED_MODES=false
 # Enable LLM-based reformulation for advanced mode only
 ENABLE_REFORMULATION=false
 
-# Use clipboard paste for longer outputs instead of typing character by character
-PASTE_THRESHOLD_WORDS=10
+# Clipboard paste timing (paste is the only output path; these only matter
+# when the opt-in clipboard verification flag is set in code)
 CLIPBOARD_VERIFY_DELAY_MS=50
 CLIPBOARD_MAX_RETRIES=5
 

--- a/src/dicton/__init__.py
+++ b/src/dicton/__init__.py
@@ -1,6 +1,6 @@
 """Dicton - cross-platform voice-to-text dictation."""
 
-__version__ = "1.14.0"
+__version__ = "1.14.2"
 __author__ = "asi0 flammeus"
 __description__ = "Voice-to-text dictation with direct transcription and translation"
 

--- a/src/dicton/adapters/config/config_env.py
+++ b/src/dicton/adapters/config/config_env.py
@@ -88,7 +88,6 @@ def load_app_config() -> AppConfig:
         filter_fillers=_env_bool("FILTER_FILLERS", "true"),
         enable_reformulation=_env_bool("ENABLE_REFORMULATION", "false"),
         enable_advanced_modes=_env_bool("ENABLE_ADVANCED_MODES", "false"),
-        paste_threshold_words=_env_int("PASTE_THRESHOLD_WORDS", "-1"),
         clipboard_verify_delay_ms=_env_int("CLIPBOARD_VERIFY_DELAY_MS", "50"),
         clipboard_max_retries=_env_int("CLIPBOARD_MAX_RETRIES", "5"),
         # Transcript cleaning

--- a/src/dicton/adapters/output/factory.py
+++ b/src/dicton/adapters/output/factory.py
@@ -9,7 +9,6 @@ from .base import TextOutput
 def get_text_output(
     clipboard=None,
     *,
-    paste_threshold_words: int = -1,
     debug: bool = False,
     clipboard_verify_delay_ms: int = 50,
     clipboard_max_retries: int = 5,
@@ -20,7 +19,6 @@ def get_text_output(
 
         return LinuxTextOutput(
             clipboard,
-            paste_threshold_words=paste_threshold_words,
             debug=debug,
             clipboard_verify_delay_ms=clipboard_verify_delay_ms,
             clipboard_max_retries=clipboard_max_retries,

--- a/src/dicton/adapters/output/linux.py
+++ b/src/dicton/adapters/output/linux.py
@@ -15,7 +15,6 @@ class LinuxTextOutput(TextOutput):
         self,
         clipboard=None,
         *,
-        paste_threshold_words: int = -1,
         debug: bool = False,
         clipboard_verify_delay_ms: int = 50,
         clipboard_max_retries: int = 5,
@@ -32,7 +31,6 @@ class LinuxTextOutput(TextOutput):
             clipboard_max_retries=clipboard_max_retries,
         )
         self._clipboard = clipboard
-        self._paste_threshold_words = paste_threshold_words
         self._verify_clipboard_enabled = verify_clipboard
         self._pynput_fallback = PynputTextOutput()
 
@@ -40,17 +38,16 @@ class LinuxTextOutput(TextOutput):
         if not text:
             return
 
-        word_count = len(text.split())
-        threshold = self._paste_threshold_words
-        use_paste = threshold == -1 or (threshold > 0 and word_count > threshold)
+        # Paste only — no word-count branching, no configurable threshold.
+        # If clipboard paste fails (no clipboard, xclip missing, X session
+        # broken), fall back to xdotool then pynput as a last-resort safety
+        # net so a dictation is never silently dropped. This fallback is not
+        # user-configurable.
+        if self.paste_text(text):
+            return
 
-        if use_paste:
-            if self._debug:
-                print(f"📋 Using paste for {word_count} words (threshold: {threshold})")
-            if self.paste_text(text):
-                return
-            if self._debug:
-                print("⚠ Paste failed, falling back to streaming")
+        if self._debug:
+            print("⚠ Paste failed, falling back to xdotool type")
 
         try:
             subprocess.run(
@@ -58,10 +55,10 @@ class LinuxTextOutput(TextOutput):
                 timeout=60,
             )
         except FileNotFoundError:
-            print("⚠ xdotool not found, using fallback method")
+            print("⚠ xdotool not found, using pynput fallback")
             self._pynput_fallback.insert_text(text, delay_ms)
         except Exception as e:
-            print(f"⚠ xdotool error: {e}, using fallback")
+            print(f"⚠ xdotool error: {e}, using pynput fallback")
             self._pynput_fallback.insert_text(text, delay_ms)
 
     def paste_text(self, text: str) -> bool:

--- a/src/dicton/orchestration/container.py
+++ b/src/dicton/orchestration/container.py
@@ -107,7 +107,6 @@ def build_runtime_service(log_path: Path | None = None) -> RuntimeService:
     clipboard = get_clipboard(debug=app_config.debug)
     text_output = get_text_output(
         clipboard,
-        paste_threshold_words=app_config.paste_threshold_words,
         debug=app_config.debug,
         clipboard_verify_delay_ms=app_config.clipboard_verify_delay_ms,
         clipboard_max_retries=app_config.clipboard_max_retries,

--- a/src/dicton/shared/app_config.py
+++ b/src/dicton/shared/app_config.py
@@ -64,7 +64,6 @@ class AppConfig:
     filter_fillers: bool
     enable_reformulation: bool
     enable_advanced_modes: bool
-    paste_threshold_words: int
     clipboard_verify_delay_ms: int
     clipboard_max_retries: int
 

--- a/src/dicton/shared/config.py
+++ b/src/dicton/shared/config.py
@@ -299,11 +299,6 @@ class Config:
     # When enabled, uses LLM for smarter cleanup. When disabled, uses local filler removal only.
     ENABLE_REFORMULATION = os.getenv("ENABLE_REFORMULATION", "false").lower() == "true"
 
-    # Paste threshold: texts with more words than this will use clipboard paste
-    # instead of character-by-character streaming (faster for long dictations)
-    # Set to 0 to always use streaming, or -1 to always use paste (default)
-    PASTE_THRESHOLD_WORDS = int(os.getenv("PASTE_THRESHOLD_WORDS", "-1"))
-
     # Clipboard timing settings — DEPRECATED.
     # The verify-clipboard poll loop is disabled by default since Dicton 1.14.0
     # (xclip is synchronous on selection ownership on plain X11). These knobs
@@ -366,7 +361,6 @@ class Config:
         cls.LANGUAGE = os.getenv("LANGUAGE", "auto")
         cls.FILTER_FILLERS = os.getenv("FILTER_FILLERS", "true").lower() == "true"
         cls.ENABLE_REFORMULATION = os.getenv("ENABLE_REFORMULATION", "false").lower() == "true"
-        cls.PASTE_THRESHOLD_WORDS = int(os.getenv("PASTE_THRESHOLD_WORDS", "-1"))
         cls.CLIPBOARD_VERIFY_DELAY_MS = int(os.getenv("CLIPBOARD_VERIFY_DELAY_MS", "50"))
         cls.CLIPBOARD_MAX_RETRIES = int(os.getenv("CLIPBOARD_MAX_RETRIES", "5"))
         cls.DEBUG = os.getenv("DEBUG", "false").lower() == "true"

--- a/tests/test_text_output_linux.py
+++ b/tests/test_text_output_linux.py
@@ -26,18 +26,20 @@ def clipboard():
 def output(clipboard):
     from dicton.adapters.output.linux import LinuxTextOutput
 
-    return LinuxTextOutput(clipboard=clipboard, paste_threshold_words=0)
+    return LinuxTextOutput(clipboard=clipboard)
 
 
-def test_insert_text_uses_xdotool(output):
+def test_insert_text_always_pastes(output, clipboard):
+    """Paste is the only output path — no word-count branching."""
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
-        output.insert_text("hello world", delay_ms=10)
+        output.insert_text("hi", delay_ms=10)
 
-    mock_run.assert_called_once()
-    args = mock_run.call_args[0][0]
-    assert args[0] == "xdotool"
-    assert "hello world" in args
+    clipboard.set_clipboard.assert_called_once_with("hi")
+    calls = [str(c) for c in mock_run.call_args_list]
+    assert any("ctrl+shift+v" in c for c in calls)
+    # Never typed character-by-character.
+    assert not any("xdotool" in c and "type" in c for c in calls)
 
 
 def test_insert_text_empty_string_is_noop(output):
@@ -46,7 +48,21 @@ def test_insert_text_empty_string_is_noop(output):
     mock_run.assert_not_called()
 
 
-def test_insert_text_falls_back_on_file_not_found(output):
+def test_insert_text_falls_back_to_xdotool_type_when_paste_fails(output, clipboard):
+    """When paste truly cannot land, fall back to xdotool type as a safety net."""
+    clipboard.set_clipboard.return_value = False
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        output.insert_text("hello", delay_ms=10)
+
+    args_lists = [c[0][0] for c in mock_run.call_args_list]
+    # The fallback is xdotool type — clipboard failure must not silently drop.
+    assert any(a[:2] == ["xdotool", "type"] and "hello" in a for a in args_lists)
+
+
+def test_insert_text_falls_back_to_pynput_when_xdotool_missing(output, clipboard):
+    """If clipboard fails AND xdotool is missing, the pynput fallback fires."""
+    clipboard.set_clipboard.return_value = False
     with patch("subprocess.run", side_effect=FileNotFoundError()):
         with patch.object(output._pynput_fallback, "insert_text") as fallback:
             output.insert_text("hello")
@@ -73,16 +89,3 @@ def test_paste_text_returns_false_when_set_clipboard_fails(output, clipboard):
     clipboard.set_clipboard.return_value = False
     result = output.paste_text("text")
     assert result is False
-
-
-def test_paste_uses_ctrl_shift_v(clipboard):
-    from dicton.adapters.output.linux import LinuxTextOutput
-
-    paste_output = LinuxTextOutput(clipboard=clipboard, paste_threshold_words=1)
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0)
-        paste_output.insert_text("long text here", delay_ms=10)
-
-    # Should call xdotool key ctrl+shift+v for paste path
-    calls = [str(c) for c in mock_run.call_args_list]
-    assert any("ctrl+shift+v" in c for c in calls)


### PR DESCRIPTION
## Summary

- `LinuxTextOutput.insert_text` no longer branches on word count. Paste is the only output path (clipboard set + `ctrl+shift+v`), regardless of length.
- `PASTE_THRESHOLD_WORDS` is removed from the config surface entirely (`.env.example`, `AppConfig`, `config_env`, legacy `shared.config`, container plumbing, factory). The knob no longer exists.
- If paste fails (no clipboard adapter, xclip missing, X session broken), `insert_text` falls back to `xdotool type` and then pynput as a last-resort safety net so a dictation is never silently dropped. This fallback is operational, not user-configurable.
- Bumps version to 1.14.2.

## Why

The threshold was leaking `xdotool` char-by-char typing into short dictations whenever a user had `PASTE_THRESHOLD_WORDS` set (defaults already favoured paste, but dormant values from earlier configs kept biting). There is no longer any user-visible reason to prefer typing: the clipboard verify-poll loop is gone, `xdotool` delay is 0, and the latency gap between paste and short-text typing is negligible.

## Test plan

- [x] `./scripts/check.sh lint` — clean.
- [x] `pytest tests/` — 274 passed, 24 skipped.
- [x] `tests/test_text_output_linux.py` rewritten: asserts paste-always for short text and the clipboard-failure → xdotool → pynput fallback chain.
- [ ] Manual: dictate a 1-word phrase post-install; verify it pastes (clipboard contents change, no per-character typing).
- [ ] Manual: dictate after temporarily removing `xclip`; verify the xdotool fallback fires.

## Note on stacking with #60

Branched from main (still at 1.14.0). PR #60 bumps to 1.14.1; this PR bumps to 1.14.2. Whichever merges first wins cleanly; the other will need a trivial rebase on `src/dicton/__init__.py` to keep the version monotonic.