### PR TITLE
fix(cleanup): strip known Whisper FR hallucinations

### DIFF
--- a/src/dicton/config.py
+++ b/src/dicton/config.py
@@ -41,7 +41,14 @@ DEFAULT_PROMPT = (
     "sans préfixe, sans commentaire. Conserve le sens et le registre. Garde "
     "les anglicismes et termes techniques anglais tels quels (« workflow », "
     "« commit », « review », « meeting », « pull request ») — ne traduis "
-    "jamais."
+    "jamais.\n\n"
+    "Supprime aussi silencieusement les hallucinations classiques de "
+    "Whisper si tu en croises (génériques de sous-titrage type "
+    "« Sous-titrage Société Radio-Canada », « Sous-titres réalisés par la "
+    "communauté d'Amara.org », « ❤️ par SousTitreur.com », appels à "
+    "« abonnez-vous », « merci d'avoir regardé cette vidéo », etc.). Si la "
+    "transcription est entièrement constituée de tels artefacts, renvoie "
+    "une chaîne vide."
 )
 
 

--- a/src/dicton/hallucinations.py
+++ b/src/dicton/hallucinations.py
@@ -15,14 +15,19 @@ import re
 
 _PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"sous-titrage\s+(?:de\s+la\s+)?soci[ée]t[ée]\s+radio-canada\.?", re.I),
-    re.compile(r"sous-titres?\s+(?:r[ée]alis[ée]s?\s+)?par\s+(?:la\s+)?communaut[ée]\s+d['’]?amara\.org\.?", re.I),
+    re.compile(
+        r"sous-titres?\s+(?:r[ée]alis[ée]s?\s+)?par\s+(?:la\s+)?communaut[ée]\s+d['’]?amara\.org\.?",
+        re.I,
+    ),
     re.compile(r"sous-titres?\s+(?:r[ée]alis[ée]s?\s+)?par\s+[^\n]{0,80}?\.org\.?", re.I),
     re.compile(r"sous-titres?\s+(?:r[ée]alis[ée]s?\s+)?par\s+[^\n.]{0,60}\.?", re.I),
     re.compile(r"❤️?\s*par\s+soustitreur\.com\.?", re.I),
     re.compile(r"merci\s+d['’]?avoir\s+regard[ée]\s+(?:cette\s+vid[ée]o|la\s+vid[ée]o)\.?", re.I),
     re.compile(r"n['’]?oubliez\s+pas\s+de\s+vous\s+abonner\.?", re.I),
     re.compile(r"abonnez-vous\s+(?:à\s+(?:la\s+)?chaîne|et\s+activez[^\n.]{0,40})?\.?", re.I),
-    re.compile(r"merci\s+(?:beaucoup\s+)?(?:à\s+(?:tous|vous)|d['’]avoir\s+(?:écouté|regardé))\.?", re.I),
+    re.compile(
+        r"merci\s+(?:beaucoup\s+)?(?:à\s+(?:tous|vous)|d['’]avoir\s+(?:écouté|regardé))\.?", re.I
+    ),
     re.compile(r"musique\s+(?:de\s+fin|d['’]?intro)\.?", re.I),
     re.compile(r"\[\s*(?:musique|applaudissements|silence)\s*\]", re.I),
 )

--- a/src/dicton/hallucinations.py
+++ b/src/dicton/hallucinations.py
@@ -1,0 +1,44 @@
+"""Deterministic stripper for known Whisper hallucinations.
+
+Whisper was trained on TV-subtitle corpora and reliably hallucinates a small
+set of canned phrases (subtitle credits, sign-off boilerplate, "abonnez-vous"
+nags) on silence or low-SNR audio. Cheaper and more reliable to scrub these
+deterministically before the LLM cleanup pass than to ask the LLM to do it.
+
+Patterns target French Whisper output. Each pattern is anchored to whole
+phrases so we never chew into legitimate dictation.
+"""
+
+from __future__ import annotations
+
+import re
+
+_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"sous-titrage\s+(?:de\s+la\s+)?soci[ée]t[ée]\s+radio-canada\.?", re.I),
+    re.compile(r"sous-titres?\s+(?:r[ée]alis[ée]s?\s+)?par\s+(?:la\s+)?communaut[ée]\s+d['’]?amara\.org\.?", re.I),
+    re.compile(r"sous-titres?\s+(?:r[ée]alis[ée]s?\s+)?par\s+[^\n]{0,80}?\.org\.?", re.I),
+    re.compile(r"sous-titres?\s+(?:r[ée]alis[ée]s?\s+)?par\s+[^\n.]{0,60}\.?", re.I),
+    re.compile(r"❤️?\s*par\s+soustitreur\.com\.?", re.I),
+    re.compile(r"merci\s+d['’]?avoir\s+regard[ée]\s+(?:cette\s+vid[ée]o|la\s+vid[ée]o)\.?", re.I),
+    re.compile(r"n['’]?oubliez\s+pas\s+de\s+vous\s+abonner\.?", re.I),
+    re.compile(r"abonnez-vous\s+(?:à\s+(?:la\s+)?chaîne|et\s+activez[^\n.]{0,40})?\.?", re.I),
+    re.compile(r"merci\s+(?:beaucoup\s+)?(?:à\s+(?:tous|vous)|d['’]avoir\s+(?:écouté|regardé))\.?", re.I),
+    re.compile(r"musique\s+(?:de\s+fin|d['’]?intro)\.?", re.I),
+    re.compile(r"\[\s*(?:musique|applaudissements|silence)\s*\]", re.I),
+)
+
+
+def strip_hallucinations(text: str) -> str:
+    """Remove known Whisper boilerplate hallucinations from a transcript.
+
+    Returns the input unchanged if nothing matches. Collapses the runs of
+    whitespace that a removal can leave behind.
+    """
+    if not text:
+        return text
+    out = text
+    for pat in _PATTERNS:
+        out = pat.sub(" ", out)
+    out = re.sub(r"[ \t]{2,}", " ", out)
+    out = re.sub(r"\s+([.,;:!?])", r"\1", out)
+    return out.strip()

--- a/src/dicton/pipeline.py
+++ b/src/dicton/pipeline.py
@@ -25,6 +25,7 @@ from pynput import keyboard
 from . import audio_session, fn_key, stats, stt
 from . import cleanup as cleanup_mod
 from .chunker import Chunker, ChunkParams
+from .hallucinations import strip_hallucinations
 from .config import Config
 from .output import paste
 from .visualizer import Visualizer
@@ -249,6 +250,7 @@ class Pipeline:
             except Exception as exc:
                 log.warning("chunk %d failed: %s", cid, exc)
         joined = " ".join(t for t in texts if t).strip()
+        joined = strip_hallucinations(joined)
         stt_ms = int((time.monotonic() - t_stt_start) * 1000)
 
         t_cl_start = time.monotonic()

--- a/src/dicton/pipeline.py
+++ b/src/dicton/pipeline.py
@@ -25,8 +25,8 @@ from pynput import keyboard
 from . import audio_session, fn_key, stats, stt
 from . import cleanup as cleanup_mod
 from .chunker import Chunker, ChunkParams
-from .hallucinations import strip_hallucinations
 from .config import Config
+from .hallucinations import strip_hallucinations
 from .output import paste
 from .visualizer import Visualizer
 

--- a/tests/test_hallucinations.py
+++ b/tests/test_hallucinations.py
@@ -1,0 +1,49 @@
+"""Deterministic Whisper-hallucination scrubber."""
+
+from __future__ import annotations
+
+import pytest
+
+from dicton.hallucinations import strip_hallucinations
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Sous-titrage Société Radio-Canada",
+        "Sous-titrage de la Société Radio-Canada.",
+        "Sous-titres réalisés par la communauté d'Amara.org",
+        "Sous-titres réalisés par l’Amara.org.",
+        "❤️ par SousTitreur.com",
+        "Merci d'avoir regardé cette vidéo.",
+        "Abonnez-vous à la chaîne.",
+        "N'oubliez pas de vous abonner.",
+        "[Musique]",
+    ],
+)
+def test_known_hallucinations_are_stripped(raw: str) -> None:
+    assert strip_hallucinations(raw) == ""
+
+
+def test_hallucination_around_real_text_keeps_content() -> None:
+    raw = "Bonjour, je teste la dictée. Sous-titrage Société Radio-Canada."
+    out = strip_hallucinations(raw)
+    assert "Radio-Canada" not in out
+    assert "Bonjour" in out and "dictée" in out
+
+
+def test_normal_text_is_passthrough() -> None:
+    raw = "Je voudrais relire le commit de la pull request avant le meeting."
+    assert strip_hallucinations(raw) == raw
+
+
+def test_empty_input_returns_empty() -> None:
+    assert strip_hallucinations("") == ""
+
+
+def test_collapses_double_spaces_after_removal() -> None:
+    raw = "Salut. Sous-titrage Société Radio-Canada. À demain."
+    out = strip_hallucinations(raw)
+    assert "  " not in out
+    assert out.startswith("Salut.")
+    assert out.endswith("À demain.")


### PR DESCRIPTION
## Summary
- Whisper hallucinates a small set of canned subtitle/credits phrases on silence — "Sous-titrage Société Radio-Canada", Amara.org credits, "abonnez-vous", "merci d'avoir regardé cette vidéo", etc. They're a known artifact of its TV-subtitle training corpus.
- Added `hallucinations.py` with a deterministic regex stripper, applied in `pipeline.py` right after STT join and before the LLM cleanup pass. Zero token-cost, fires on every dictation.
- Hardened `DEFAULT_PROMPT` with a fallback instruction so the LLM also strips any variant the regex misses (belt + braces).
- If a dictation is *entirely* hallucination (e.g. you held the hotkey on silence), the cleanup returns an empty string instead of pasting boilerplate.

## Test plan
- [x] `./scripts/check.sh all` — ruff lint, ruff format, pipeline LOC cap, 25/25 pytest pass
- [x] New unit tests in `tests/test_hallucinations.py` cover each known artifact, mixed-content stripping, passthrough on normal dictation, and whitespace collapsing
- [ ] Manual smoke: dictate a real sentence followed by ~3s of silence — confirm the Radio-Canada artifact no longer appears in the pasted output