### PR TITLE
fix(update): pull latest main from GitHub instead of bare uv upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Chaque commande fait, dans l'ordre :
 
 À la fin du wizard, si tu as accepté l'autostart, le daemon tourne en arrière-plan via systemd/launchd et te rend la main sur le terminal. F2 marche immédiatement.
 
+### Mise à jour
+
+```bash
+dicton update   # réinstalle le dernier main depuis GitHub + restart systemd
+```
+
+`dicton update` (sans argument) fait `uv tool install --force --reinstall git+https://github.com/Asi0Flammeus/dicton.git@main`. Il tire donc le code depuis GitHub, pas depuis le clone local — pas besoin de garder le dossier cloné, et un clone déplacé/supprimé ne casse plus la commande. `main` étant une branche mouvante, le `--reinstall` est indispensable (uv cache sinon le commit résolu et ne re-fetch jamais le HEAD). Pour itérer sur des sources locales en dev, utilise `dicton update <path>`.
+
 ## Usage
 
 | Geste                          | Effet                    |
@@ -74,7 +82,7 @@ Pendant l'enregistrement, un petit anneau orange flotte en haut à droite. Il pa
 | `dicton wizard`        | Re-lance le setup complet (clé, hotkey, modèle, autostart)                         |
 | `dicton config`        | Change uniquement le modèle de cleanup                                             |
 | `dicton stats`         | Affiche les totaux : nombre de dictées, latence moyenne, temps de frappe économisé |
-| `dicton update`        | Upgrade depuis PyPI + restart systemd                                              |
+| `dicton update`        | Réinstalle le dernier `main` depuis GitHub + restart systemd                       |
 | `dicton update <path>` | Reinstall depuis un repo local + restart systemd (dev)                             |
 
 ## Performance

--- a/src/dicton/cli.py
+++ b/src/dicton/cli.py
@@ -102,7 +102,7 @@ def stats_cmd() -> None:
 def update_cmd(
     source: str | None = typer.Argument(
         None,
-        help="Local path (development install). Omit to upgrade from PyPI.",
+        help="Local path (development install). Omit to pull the latest main from GitHub.",
     ),
     no_restart: bool = typer.Option(
         False, "--no-restart", help="Skip restarting the systemd unit after install."
@@ -110,7 +110,13 @@ def update_cmd(
 ) -> None:
     """Reinstall dicton, then restart the daemon to pick up the new code.
 
-    Without arguments, upgrades the published release via ``uv tool upgrade``.
+    Without arguments, reinstalls from the latest ``main`` on GitHub via
+    ``uv tool install --force --reinstall git+<repo>@main``. We force a full
+    reinstall (not a bare ``uv tool upgrade``) because ``main`` is a moving
+    git ref: uv caches the resolved commit, so only ``--reinstall`` (which
+    implies ``--refresh``) re-fetches the branch HEAD. This also self-heals an
+    install whose recorded source path has gone missing.
+
     With a path, rebuilds from local sources via ``uv tool install --force
     --reinstall`` — the standard dev loop. Either way, if the systemd unit is
     active it is restarted automatically so the new binary takes effect.
@@ -128,7 +134,14 @@ def update_cmd(
     else:
         if not _check_for_updates():
             return
-        cmd = ["uv", "tool", "upgrade", "dicton"]
+        cmd = [
+            "uv",
+            "tool",
+            "install",
+            "--force",
+            "--reinstall",
+            f"git+{GITHUB_REMOTE_URL}@main",
+        ]
 
     _kill_stale_dicton_on_windows()
     if sys.platform == "win32":


### PR DESCRIPTION
## Context
`check`ing the update path (per request) surfaced that `dicton update` is **broken in practice**, independent of any code merge:

1. `dicton update` (no args) ran `uv tool upgrade dicton` — which assumes a **PyPI** release.
2. `dicton` **is not published on PyPI** (`pypi.org/pypi/dicton` → 404). The `uv publish` CI job is tag-gated and has never produced a release.
3. For the common **local-dir install**, once the recorded source directory moves/deletes, `uv tool upgrade` errors hard:
   ```
   error: Failed to upgrade dicton
     Caused by: Distribution not found at: file:///…/dicton
   ```

## Change
No-arg `dicton update` now reinstalls from the live branch:
```
uv tool install --force --reinstall git+https://github.com/Asi0Flammeus/dicton.git@main
```
- Pulls code from **GitHub `main`**, not a local clone or PyPI — survives the clone being moved/deleted.
- `--reinstall` (implies `--refresh`) is **required**: `main` is a moving ref and uv otherwise serves the cached resolved commit, never re-fetching HEAD.
- Self-heals an install whose recorded source path went missing.
- Existing `_check_for_updates()` SHA comparison (local `+g<sha>` vs `main` HEAD) already aligns with this model — no change needed there.
- `dicton update <path>` dev loop unchanged.

## Test plan
- [x] `./scripts/check.sh lint` — clean
- [ ] Manual: `dicton update` on a fresh `git+…@main` install pulls a new commit after it lands on main