### PR TITLE
fix(x11): call XInitThreads() before any X connection to stop SIGSEGV

### DIFF
--- a/src/dicton/os_/x11.py
+++ b/src/dicton/os_/x11.py
@@ -1,0 +1,40 @@
+"""Process-global X11 setup. Linux/X11 only; a no-op everywhere else.
+
+The daemon talks to the X server from two threads at once: pynput's
+``keyboard.Listener`` (X11 backend) keeps a long-lived Xlib connection on a
+background thread, while pygame/SDL drives ``libX11`` on the main thread for
+the visualizer. ``libX11`` is **not** thread-safe unless ``XInitThreads()`` is
+called once, before the first X connection is opened — otherwise the two
+threads race over the shared client state, corrupt it, and the process dies
+with SIGSEGV (``status=11``). See the long comment in ``visualizer.py`` for the
+symptom history; this is the root-cause guard that makes the whole process
+safe rather than just the visualizer's own xlib connection.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+import sys
+
+log = logging.getLogger("dicton")
+
+
+def init_threads() -> None:
+    """Enable libX11 thread-safety. Must run before any X connection.
+
+    Call this at the very start of the daemon, before ``Pipeline.start()``
+    (which opens pynput's X connection) and before the visualizer's
+    ``pygame.init()`` (which opens SDL's). Safe to call when X is absent: it
+    returns immediately on non-Linux, headless, or Wayland-only sessions.
+    """
+    if not (sys.platform.startswith("linux") and os.environ.get("DISPLAY")):
+        return
+    try:
+        xlib = ctypes.cdll.LoadLibrary("libX11.so.6")
+    except OSError:
+        log.debug("libX11 not available; skipping XInitThreads()", exc_info=True)
+        return
+    if xlib.XInitThreads() == 0:
+        log.warning("XInitThreads() returned 0 — X11 thread-safety not enabled")

--- a/src/dicton/runtime.py
+++ b/src/dicton/runtime.py
@@ -7,6 +7,7 @@ import time
 
 from .config import Config
 from .os_ import single_instance as singleton
+from .os_ import x11
 from .pipeline import Pipeline
 from .visualizer import Visualizer
 
@@ -16,6 +17,9 @@ log = logging.getLogger("dicton")
 def run(cfg: Config) -> None:
     """Blocking entrypoint. Acquires the singleton lock, starts the pipeline,
     then runs the pygame loop on the main thread (required on macOS)."""
+    # Must precede every X connection: pynput's listener (Pipeline.start) and
+    # SDL (visualizer). Without it, concurrent libX11 access segfaults.
+    x11.init_threads()
     lock = singleton.acquire()
     if lock is None:
         log.error("Another dicton instance is already running. Refusing to start.")


### PR DESCRIPTION
## Symptom

The daemon was dying with `status=11/SEGV` (core-dump) roughly hourly, with systemd auto-restarting it each time. The fault is native (no Python traceback), at a near-fixed IP in `python3.12` with `segfault at 1` — the signature of concurrent memory corruption, which the visualizer loop's `try/except` can't catch.

## Root cause

`libX11` is accessed from **two threads at once**:

- `pynput.keyboard.Listener` (X11 backend) keeps a long-lived Xlib connection on a **background thread** (`pipeline.py`).
- pygame/SDL drives `libX11` on the **main thread** for the visualizer.

`libX11` is not thread-safe unless `XInitThreads()` is called once, before the first X connection. The old COPA architecture called it; the **refonte-v2 rewrite (`20d8160`) dropped it** while keeping both concurrent X clients — a regression. `visualizer.py:110` already documents this exact `status=11/SEGV`, but its fix only made the visualizer's *own* xlib connection short-lived; pynput's connection still races SDL.

The configured trigger (`f2`) rides pynput (it is not an Fn key, so evdev can't take it), so the pynput X listener can't simply be removed — the correct fix is the process-global `XInitThreads()`.

## Fix

- New `os_/x11.py` with `init_threads()` that loads `libX11.so.6` and calls `XInitThreads()` once. No-op on non-Linux / headless / Wayland (keeps the `os_/` platform-isolation invariant from #67).
- Called at the top of `runtime.run()`, before `Pipeline.start()` (pynput) and the visualizer's `pygame.init()` (SDL).

## Validation

- `./scripts/check.sh lint` clean; `uv run pytest` green (28 passed, incl. `test_no_platform_leak`).
- Deployed as a dev-install: daemon starts clean, `XInitThreads()` returns success (no warning), no startup crash.
- Definitive proof (zero SEGV over several hours) is observational — pre-fix the crash recurred ~hourly.