### PR TITLE
fix(paste): don't capture clipboard-daemon output, fixing multi-minute paste hang

### DIFF
--- a/src/dicton/os_/paste/_linux.py
+++ b/src/dicton/os_/paste/_linux.py
@@ -29,8 +29,22 @@ def paste_linux(text: str) -> None:
     errors: list[str] = []
     for copy_cmd, send in _paste_strategies():
         try:
-            subprocess.run(copy_cmd, input=data, check=True, capture_output=True)
-        except (OSError, subprocess.CalledProcessError) as exc:
+            # DEVNULL, not capture_output: xclip/wl-copy fork a daemon to serve
+            # the selection, and that daemon inherits the stdout/stderr PIPEs.
+            # communicate() then blocks on EOF until the daemon dies (i.e. until
+            # the next copy replaces the selection) — a multi-minute hang that
+            # leaves send() never called, so paste silently never fires. With
+            # DEVNULL there is no pipe to drain: run() returns as soon as the
+            # short-lived parent exits. timeout is a belt-and-suspenders cap.
+            subprocess.run(
+                copy_cmd,
+                input=data,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
             errors.append(f"{copy_cmd[0]} ({exc})")
             continue
         time.sleep(0.02)


### PR DESCRIPTION
## Symptom

Auto-paste silently stopped working on X11. The transcription completes (clipboard text is computed) but nothing is pasted into the focused app. Logs show the dictation summary appearing **minutes** after the audio ended, e.g. `process=260880ms` while `stt=302ms cleanup=511ms`.

## Root cause

`paste_linux()` copies via `subprocess.run(copy_cmd, input=data, check=True, capture_output=True)`. `xclip`/`wl-copy` **fork a daemon** to keep serving the X/Wayland selection after the parent exits, and that daemon inherits `subprocess.run`'s stdout/stderr **pipes**. `communicate()` then blocks waiting for EOF on those pipes — which only happens when the daemon dies, i.e. when the *next* copy replaces the selection. During that hang the `Ctrl+Shift+V` keystroke (sent only *after* the copy returns) is never issued, so paste does nothing.

Latent since the refonte-v2 rewrite; it was masked whenever a clipboard manager (or a quick next dictation) promptly took over the selection and let `xclip` exit. When nothing reclaims the clipboard, it hangs for minutes.

## Fix

Copy with `stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL` instead of `capture_output=True`: no pipe to drain, so `run()` returns as soon as the short-lived parent forks and exits, regardless of the daemon's lifetime. Added a `timeout=5` safety net (and catch `TimeoutExpired`) so a wedged copy fails over to the next strategy instead of hanging.

## Validation

- `./scripts/check.sh lint` clean; `uv run pytest` green (28 passed, incl. the 3 `test_output.py` paste tests).
- Deployed as a dev-install; daemon healthy. End-to-end paste re-verified on the reporting machine.