### PR TITLE
feat: voice-triggered text macros (spoken trigger → verbatim value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ dicton update   # réinstalle le dernier main depuis GitHub + restart systemd
 
 Pendant l'enregistrement, un petit anneau orange flotte en haut à droite. Il passe en pulse concentrique pendant le processing (STT + cleanup), puis disparaît quand le texte est collé. Les players audio (Spotify, YouTube, VLC…) sont mis en pause automatiquement pendant que tu parles, et repris à la fin.
 
+### Macros
+
+Une macro remplace un déclencheur prononcé par un texte inséré **verbatim** — d'une URL (« crqpt url » → `https://crqpt.com`) à un bloc multi-paragraphes (signature). `dicton macros` ouvre l'éditeur : déclencheur tapé ou 🎤 enregistré (la transcription Whisper brute devient une « orthographe » ; ajoutes-en d'autres quand Whisper varie), valeur multi-lignes. La détection est inline sur chaque dictée, insensible à la casse/aux accents/à la ponctuation, et la valeur contourne le cleanup LLM — elle est collée octet pour octet. Stockage : `~/.config/dicton/macros.json`, relu à la volée (pas de restart). Détails : [docs/features/macros.md](docs/features/macros.md).
+
 ## Commandes
 
 | Commande               | Effet                                                                              |
@@ -93,6 +97,7 @@ Pendant l'enregistrement, un petit anneau orange flotte en haut à droite. Il pa
 | `dicton`               | Lance le daemon (ou délègue au service systemd si autostart actif)                 |
 | `dicton wizard`        | Re-lance le setup complet (clé, hotkey, modèle, autostart)                         |
 | `dicton config`        | Change uniquement le modèle de cleanup                                             |
+| `dicton macros`        | Ouvre l'éditeur de macros (déclencheur parlé → texte collé verbatim)               |
 | `dicton stats`         | Affiche les totaux : nombre de dictées, latence moyenne, temps de frappe économisé |
 | `dicton update`        | Réinstalle le dernier `main` depuis GitHub + restart systemd                       |
 | `dicton update <path>` | Reinstall depuis un repo local + restart systemd (dev)                             |
@@ -129,6 +134,8 @@ src/dicton/
 ├── chunker.py      Découpage silence-aware avec overlap, RMS dBFS.
 ├── stt.py          Whisper turbo via httpx HTTP/2 partagé.
 ├── cleanup.py      LLM cleanup en français, prompt verrouillé.
+├── macros.py       Expansion de macros : matching normalisé aux frontières de mots, jeton opaque autour du cleanup, valeur byte-exact, macros.json relu via cache mtime.
+├── macros_ui.py    Éditeur Qt `dicton macros` (CRUD + 🎤 orthographe via STT), découplé du daemon — ils ne partagent que macros.json.
 ├── output.py       Clipboard + Ctrl+Shift+V (xclip+xdotool / wl-copy+wtype / pbcopy+osascript / SetClipboardData+SendInput).
 ├── visualizer.py   Donut FFT pygame, XShape circulaire sur X11, hide via shape-mask (jamais de show/hide window → pas de focus stealing).
 ├── fn_key.py       Listener evdev pour Fn (KEY_WAKEUP 143 + KEY_FN 464-466), détection double-tap.

--- a/docs/features/macros.md
+++ b/docs/features/macros.md
@@ -1,0 +1,192 @@
+# Macros — expansion de texte déclenchée à la voix
+
+## Concept
+
+Une **Macro** associe un **déclencheur** parlé à une **valeur** insérée verbatim. Pendant une
+dictée, si l'utilisateur prononce un déclencheur (« crqpt url »), dicton remplace l'occurrence
+par la valeur définie (`https://crqpt.com`) — du simple lien jusqu'au bloc multi-paragraphes.
+
+Langage ubiquitaire :
+
+| Terme               | Définition                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------- |
+| **Macro**           | `{ déclencheur(s) → valeur }`. Nom de code `macro` ; jamais prononcé (détection inline).     |
+| **Orthographe** (`spelling`) | Une transcription Whisper connue du déclencheur. Une macro en porte **une ou plusieurs**. |
+| **Valeur** (`value`) | Le texte de remplacement, **byte-exact**, éventuellement multi-paragraphes.                  |
+| **Jeton** (`token`) | Sentinelle opaque qui remplace temporairement la valeur pendant le cleanup LLM.             |
+
+> Le nom « Snippet » est écarté : déjà employé par Wispr Flow.
+
+## Problème central — pourquoi ce n'est pas un simple `str.replace`
+
+Deux contraintes se combinent et dictent toute l'architecture :
+
+1. **Whisper n'est pas déterministe.** « crqpt » est transcrit `crypte` / `CRQPT` / `cripte` selon
+   la prise. Un match littéral raterait souvent → on enregistre **plusieurs orthographes** par macro
+   et on **normalise** avant de comparer.
+2. **La valeur est byte-exact.** Le LLM de cleanup ne doit jamais la voir (il paraphraserait une URL,
+   reformaterait un bloc) → la valeur **contourne** le cleanup via un jeton placeholder.
+
+Activation retenue : **inline nue** (pas de mot-sentinelle ; on scanne chaque dictée). C'est la plus
+naturelle mais la moins robuste ; le filet de sécurité est la liste d'orthographes, curable à la volée.
+Repli futur si l'inline déborde : ajouter un mot-sentinelle optionnel — le modèle de données ci-dessous
+y survit sans réécriture.
+
+## Décisions
+
+| Branche             | Décision                                                                                                   |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Nom**             | Macro                                                                                                       |
+| **Détection**       | Inline nue — chaque dictée est scannée, sans mot-sentinelle                                                 |
+| **Matching**        | Normalisation (minuscules, sans accents/ponctuation, espaces compactés) + « contient » **aux frontières de mots** ; orthographes multiples ; **la plus longue gagne** |
+| **Valeur**          | Byte-exact, multi-paragraphes ; **saisie au clavier** dans la fenêtre (pas de presse-papiers)              |
+| **Sécurité LLM**    | Placeholder en deux temps : détection sur le brut → jeton → cleanup → restauration → valeur verbatim        |
+| **Édition**         | Fenêtre Qt autonome (`dicton macros`) : liste / créer / éditer / supprimer                                 |
+| **Saisie déclencheur** | Tapée **ou** 🎤 enregistrée → stocke la transcription Whisper **brute** ; « + ajouter une orthographe » |
+| **Stockage**        | `~/.config/dicton/macros.json` (stdlib, zéro dépendance ; YAML possible plus tard si lisibilité voulue)    |
+| **Rechargement**    | Le daemon **relit `macros.json`** au moment de matcher (cache mtime) — pas de redémarrage, pas d'IPC        |
+| **Ouverture fenêtre** | `dicton macros` (CLI) — pas de 3ᵉ hotkey global                                                           |
+
+## Modèle de données — `~/.config/dicton/macros.json`
+
+```json
+[
+  {
+    "id": "crqpt-url",
+    "spellings": ["crqpt url", "crypte url", "CRQPT URL"],
+    "value": "https://crqpt.com"
+  },
+  {
+    "id": "signature",
+    "spellings": ["ma signature"],
+    "value": "Cordialement,\nAsi0\n— alysis"
+  }
+]
+```
+
+- `id` : identifiant stable (slug ou uuid4 court) pour que la fenêtre édite/supprime sans dépendre de
+  l'index du tableau.
+- `spellings` : ≥ 1. C'est la liste qu'on enrichit quand Whisper surprend.
+- `value` : verbatim, `\n` inclus. Écrite par l'app (échappement correct), jamais à la main.
+
+Fichier en `0o600` (cohérent avec `config.toml`, même répertoire XDG). Synchronisable via les clouds
+si symlinké.
+
+## Règles de matching (et cas-limites)
+
+Normalisation `normalize(s)` : `casefold()` → NFKD + suppression des diacritiques → conservation des
+seuls alphanumériques + espaces → compactage des espaces.
+
+| Cas                                    | Comportement                                                              |
+| -------------------------------------- | ------------------------------------------------------------------------ |
+| Plusieurs orthographes d'une macro     | N'importe laquelle matche                                                 |
+| Frontières de mots                     | « url » ne déclenche **pas** dans « urlencode » (match sur suite de mots entiers) |
+| Plusieurs occurrences dans une dictée  | **Toutes** remplacées                                                     |
+| Deux macros matchent un texte chevauchant | **L'orthographe la plus longue gagne** (évite l'ombrage partiel)       |
+| Dictée = uniquement le déclencheur     | Expansion en la seule valeur (tombe naturellement)                       |
+| Valeur en début de phrase              | Insérée **verbatim** (le byte-exact prime sur l'auto-majuscule)          |
+
+## Sécurité LLM — placeholder en deux temps
+
+Point d'insertion : `src/dicton/pipeline.py:320` (juste après `joined`, autour de l'appel
+`cleanup_mod.cleanup` ligne 329).
+
+```
+BRUT     "envoie le crqpt url au client"
+  expand()  →  détecte + tokenise
+TOKENISÉ "envoie le ⟦M0⟧ au client"          (⟦M0⟧ = jeton opaque, U+E000…)
+  cleanup LLM  (le jeton est une donnée inerte, préservée mot pour mot)
+NETTOYÉ  "Envoie le ⟦M0⟧ au client."
+  restore()  →  ⟦M0⟧ → valeur
+FINAL    "Envoie le https://crqpt.com au client."
+```
+
+La valeur n'est **jamais** vue par le LLM ; la phrase autour est tout de même corrigée.
+
+**Risque clé — survie du jeton.** Le modèle de cleanup pourrait supprimer un caractère exotique. C'est
+le seul défaut capable de casser la feature silencieusement.
+- *Mitigation 1* : choisir un jeton que les modèles préservent de façon fiable, **validé empiriquement**
+  contre les 4 modèles de `CLEANUP_MODELS` (test d'intégration, pas seulement mock).
+- *Mitigation 2 (repli)* : si **un** jeton manque dans la sortie nettoyée → on jette le résultat du
+  cleanup et on restaure les jetons dans le texte **tokenisé pré-cleanup**. La macro se déclenche
+  toujours (valeur byte-exact présente), au prix de la passe de polish dans ce cas rare. Priorité
+  assumée : fiabilité de la feature > polish.
+
+## Architecture — éditeur découplé du daemon
+
+Le choix `dicton macros` (CLI) rend l'éditeur **indépendant** du daemon ; ils ne se rencontrent qu'à
+travers le fichier JSON.
+
+```
+dicton macros (process fenêtre Qt)         daemon (process long)
+  ├─ CRUD sur macros.json                     ├─ à chaque dictée :
+  ├─ 🎤 : capture courte + stt.transcribe()    │    relit macros.json (cache mtime)
+  └─ écrit macros.json                  ─────► └─ expand()/restore() autour du cleanup
+```
+
+- Pas d'IPC, pas de file-watcher, pas de redémarrage.
+- La 🎤 réutilise `src/dicton/stt.py:transcribe` (httpx + clé Groq de `config`). Seul coût accepté :
+  un second petit chemin enregistrement→STT, mais c'est une **réutilisation** d'une fonction propre,
+  pas une réimplémentation.
+
+## Fenêtre `dicton macros`
+
+```
+ Macros                                   [ + Nouvelle ]
+ ──────────────────────────────────────────────────────
+  crqpt url            → https://crqpt.com
+  ma signature         → Cordialement, …
+ ──────────────────────────────────────────────────────
+  Édition : « crqpt url »
+    Déclencheur (ce que tu dis) :
+      [ crqpt url                         ]  🎤
+      [ + ajouter une orthographe              ]
+    Valeur (insérée verbatim) :
+      ┌────────────────────────────────────┐
+      │ https://crqpt.com                  │
+      │ (multi-lignes, byte-exact)         │
+      └────────────────────────────────────┘
+                 [ Enregistrer ]   [ Supprimer ]
+```
+
+## Plan d'implémentation (tracer-bullet)
+
+### Phase 1 — Le moteur (les macros se déclenchent, sans UI)
+
+- `src/dicton/macros.py` :
+  - `@dataclass Macro: id: str; spellings: list[str]; value: str`
+  - `load() -> list[Macro]` / `save(...)` sur `macros.json`, cache mtime.
+  - `normalize(s) -> str`
+  - `expand(raw, macros) -> tuple[str, dict[str, str]]` (texte tokenisé + map jeton→valeur)
+  - `restore(text, token_map) -> str` (+ repli si jeton manquant)
+- Branchement `pipeline.py:_end` : `tokenized, tok = macros.expand(joined, macros.load())` →
+  cleanup sur `tokenized` → `cleaned = macros.restore(cleaned, tok)`.
+- `tests/test_macros.py` : normalisation (accents/casse/ponctuation), frontières de mots,
+  orthographes multiples, la-plus-longue-gagne, occurrences multiples, round-trip expand/restore,
+  **survie du jeton au cleanup** (mock respx) + **repli** quand le jeton est supprimé.
+- Manuel : seed `macros.json` → dictée → la macro se déclenche de bout en bout.
+
+**Livrable Phase 1** : feature fonctionnelle via `macros.json` édité à la main, avant toute GUI.
+
+### Phase 2 — Fenêtre `dicton macros`
+
+- `src/dicton/macros_ui.py` (Qt) : liste, créer, éditer (orthographes + valeur multi-lignes),
+  supprimer, écrire `macros.json`.
+- 🎤 : `sounddevice.InputStream` court + `stt.transcribe` → remplit le champ orthographe avec le brut.
+- `cli.py` : sous-commande `dicton macros` (motif Typer, comme `dicton config`).
+- Tests : logique CRUD (séparée de Qt autant que possible) ; câblage capture STT (mock).
+
+### Phase 3 — Polish
+
+- Validation (déclencheur/valeur vides ; orthographe en doublon entre macros → avertir).
+- Optionnel : panneau « transcriptions brutes récentes » pour récupérer une orthographe après un raté.
+- README + cette doc finalisés.
+
+Chaque phase se clôt sur la **gate de validation** du repo : `./scripts/check.sh lint` + `pytest` au vert
+(cf. `CLAUDE.md`).
+
+## Hors-scope (v1)
+
+Contenu dynamique (date / presse-papiers / variables), macros par application, macros imbriquées,
+regex, mot-sentinelle. Le sentinelle reste le repli le moins cher si l'inline nue se révèle trop
+bruyante à l'usage.

--- a/docs/features/macros.md
+++ b/docs/features/macros.md
@@ -94,10 +94,10 @@ Point d'insertion : `src/dicton/pipeline.py:320` (juste après `joined`, autour 
 ```
 BRUT     "envoie le crqpt url au client"
   expand()  →  détecte + tokenise
-TOKENISÉ "envoie le ⟦M0⟧ au client"          (⟦M0⟧ = jeton opaque, U+E000…)
+TOKENISÉ "envoie le QZM0XQZ au client"        (QZM0XQZ = jeton opaque alphanumérique)
   cleanup LLM  (le jeton est une donnée inerte, préservée mot pour mot)
-NETTOYÉ  "Envoie le ⟦M0⟧ au client."
-  restore()  →  ⟦M0⟧ → valeur
+NETTOYÉ  "Envoie le QZM0XQZ au client."
+  restore()  →  QZM0XQZ → valeur
 FINAL    "Envoie le https://crqpt.com au client."
 ```
 
@@ -111,6 +111,14 @@ le seul défaut capable de casser la feature silencieusement.
   cleanup et on restaure les jetons dans le texte **tokenisé pré-cleanup**. La macro se déclenche
   toujours (valeur byte-exact présente), au prix de la passe de polish dans ce cas rare. Priorité
   assumée : fiabilité de la feature > polish.
+
+**Résultat de la validation empirique** (3 prises × 4 modèles par candidat, prompt de cleanup réel) :
+toute décoration se fait arracher par au moins un modèle Llama — `⟦M0⟧`, `[[M0]]`, `{{M0}}`,
+`@@M0@@`, `__M0__` ressortent en `M0` nu sur `llama-3.1-8b-instant`, et U+E000 (zone privée) est
+supprimé par 3 modèles sur 4. En revanche la **suite alphanumérique intérieure survit toujours** :
+le jeton retenu est donc *uniquement* une suite alphanumérique opaque, `QZM{i}XQZ`, préservée 12/12
+par les 4 modèles. Le test `test_token_survives_real_models` (gated sur `GROQ_API_KEY`) rejoue
+cette validation contre l'API réelle.
 
 ## Architecture — éditeur découplé du daemon
 
@@ -149,7 +157,11 @@ dicton macros (process fenêtre Qt)         daemon (process long)
                  [ Enregistrer ]   [ Supprimer ]
 ```
 
-## Plan d'implémentation (tracer-bullet)
+## Plan d'implémentation (tracer-bullet) — ✅ implémenté
+
+État : les trois phases sont livrées (`src/dicton/macros.py`, `src/dicton/macros_ui.py`,
+`dicton macros` dans `cli.py`, branchement dans `pipeline.py:_end`, tests
+`tests/test_macros.py` + `tests/test_macros_ui.py`).
 
 ### Phase 1 — Le moteur (les macros se déclenchent, sans UI)
 

--- a/src/dicton/cli.py
+++ b/src/dicton/cli.py
@@ -118,6 +118,17 @@ def _restart_hint() -> None:
     console.print("Restart the daemon to apply: [cyan]systemctl --user restart dicton[/cyan]")
 
 
+@app.command(name="macros")
+def macros_cmd() -> None:
+    """Edit voice macros (spoken trigger → text inserted verbatim)."""
+    if not config.exists():
+        console.print("[red]No config yet[/red] — run `dicton wizard` first.")
+        raise typer.Exit(1)
+    from .macros_ui import run_window
+
+    raise typer.Exit(run_window(config.load()))
+
+
 @app.command(name="stats")
 def stats_cmd() -> None:
     """Show lifetime usage summary."""

--- a/src/dicton/macros.py
+++ b/src/dicton/macros.py
@@ -1,0 +1,188 @@
+"""Voice-triggered text macros — spoken trigger → byte-exact value.
+
+A Macro maps one or more *spellings* (known Whisper transcriptions of the
+spoken trigger) to a verbatim replacement value. Detection is inline: every
+dictation is scanned, no sentinel word. Matching is done on a normalized
+form (casefold, no diacritics/punctuation, compacted spaces) at word
+boundaries, longest spelling wins, all occurrences are replaced.
+
+The value must never reach the cleanup LLM (it would paraphrase a URL or
+reformat a block), so expansion happens in two steps around the cleanup:
+``expand()`` swaps each match for an opaque token before cleanup and
+``restore()`` swaps tokens back for the verbatim value afterwards — with a
+fallback to the pre-cleanup text if the model dropped a token.
+
+The editor window (`dicton macros`) and the daemon never talk to each other;
+they only share ``macros.json``, re-read on every dictation via an mtime
+cache.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import unicodedata
+from dataclasses import asdict, dataclass
+
+from .config import CONFIG_DIR
+
+log = logging.getLogger("dicton")
+
+MACROS_PATH = CONFIG_DIR / "macros.json"
+
+# Token sentinels, chosen empirically against the 4 CLEANUP_MODELS (see
+# test_token_survives_real_models): a bare opaque alphanumeric blob is the
+# only form every model returns verbatim. Decorated forms (\u27e6M0\u27e7, [[M0]],
+# {{M0}}, @@M0@@, __M0__, U+E000 private-use) all get their decoration
+# stripped by at least one Llama model \u2014 but the inner alphanumeric run
+# always survives, so the token IS only an alphanumeric run. restore()
+# still has a fallback if a model mangles one anyway.
+_TOK_OPEN = "QZM"
+_TOK_CLOSE = "XQZ"
+
+
+@dataclass
+class Macro:
+    id: str
+    spellings: list[str]
+    value: str
+
+
+# ---- storage ----
+
+_cache: tuple[float, list[Macro]] | None = None
+
+
+def load() -> list[Macro]:
+    """Read macros.json, cached on mtime so the daemon can call this on every
+    dictation without re-parsing. Missing or corrupt file → no macros."""
+    global _cache
+    try:
+        mtime = MACROS_PATH.stat().st_mtime
+    except OSError:
+        _cache = None
+        return []
+    if _cache is not None and _cache[0] == mtime:
+        return _cache[1]
+    try:
+        raw = json.loads(MACROS_PATH.read_text(encoding="utf-8"))
+        macros = [
+            Macro(
+                id=str(d["id"]), spellings=[str(s) for s in d["spellings"]], value=str(d["value"])
+            )
+            for d in raw
+        ]
+    except (OSError, ValueError, KeyError, TypeError):
+        log.warning("macros.json is unreadable — macros disabled until fixed")
+        _cache = None
+        return []
+    _cache = (mtime, macros)
+    return macros
+
+
+def save(macros: list[Macro]) -> None:
+    global _cache
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    body = json.dumps([asdict(m) for m in macros], ensure_ascii=False, indent=2)
+    MACROS_PATH.write_text(body + "\n", encoding="utf-8")
+    with contextlib.suppress(OSError):
+        os.chmod(MACROS_PATH, 0o600)
+    _cache = None
+
+
+# ---- matching ----
+
+
+def normalize(s: str) -> str:
+    """Casefold, strip diacritics, drop punctuation, compact spaces."""
+    folded = unicodedata.normalize("NFKD", s.casefold())
+    kept = (ch if ch.isalnum() else " " for ch in folded if not unicodedata.combining(ch))
+    return " ".join("".join(kept).split())
+
+
+def _words(raw: str) -> list[tuple[int, int, str]]:
+    """Words of ``raw`` as (start, end, normalized) with raw-text offsets, so a
+    match found on normalized words can be spliced out of the raw text."""
+    words: list[tuple[int, int, str]] = []
+    start = -1
+    end = -1
+    buf: list[str] = []
+    for i, ch in enumerate(raw):
+        norm = "".join(
+            c for c in unicodedata.normalize("NFKD", ch.casefold()) if not unicodedata.combining(c)
+        )
+        if norm and all(c.isalnum() for c in norm):
+            if start < 0:
+                start = i
+            buf.append(norm)
+            end = i + 1
+        elif start >= 0:
+            words.append((start, end, "".join(buf)))
+            start, buf = -1, []
+    if start >= 0:
+        words.append((start, end, "".join(buf)))
+    return words
+
+
+def expand(raw: str, macros: list[Macro]) -> tuple[str, dict[str, str]]:
+    """Replace every spelling match in ``raw`` with an opaque token.
+
+    Returns the tokenized text plus the token → value map for ``restore()``.
+    Matching is word-boundary on normalized words; at each position the
+    longest matching spelling wins (avoids partial shadowing between macros).
+    """
+    if not raw or not macros:
+        return raw, {}
+    table: dict[tuple[str, ...], str] = {}
+    for m in macros:
+        for sp in m.spellings:
+            key = tuple(normalize(sp).split())
+            if key:
+                table.setdefault(key, m.value)
+    if not table:
+        return raw, {}
+
+    words = _words(raw)
+    max_words = max(len(k) for k in table)
+    out: list[str] = []
+    token_map: dict[str, str] = {}
+    pos = 0
+    i = 0
+    while i < len(words):
+        matched = 0
+        for n in range(min(max_words, len(words) - i), 0, -1):
+            if tuple(w[2] for w in words[i : i + n]) in table:
+                matched = n
+                break
+        if matched:
+            start, end = words[i][0], words[i + matched - 1][1]
+            token = f"{_TOK_OPEN}M{len(token_map)}{_TOK_CLOSE}"
+            token_map[token] = table[tuple(w[2] for w in words[i : i + matched])]
+            out.append(raw[pos:start])
+            out.append(token)
+            pos = end
+            i += matched
+        else:
+            i += 1
+    out.append(raw[pos:])
+    return "".join(out), token_map
+
+
+def restore(text: str, token_map: dict[str, str], *, fallback: str | None = None) -> str:
+    """Swap tokens back for their verbatim values.
+
+    If the cleanup model dropped any token, the cleaned text can no longer be
+    trusted to carry the macro: discard it and restore on ``fallback`` (the
+    pre-cleanup tokenized text) instead — the macro still fires, at the cost
+    of the polish pass. Feature reliability beats polish.
+    """
+    if not token_map:
+        return text
+    if fallback is not None and any(tok not in text for tok in token_map):
+        log.warning("cleanup dropped a macro token — restoring on pre-cleanup text")
+        text = fallback
+    for token, value in token_map.items():
+        text = text.replace(token, value)
+    return text

--- a/src/dicton/macros.py
+++ b/src/dicton/macros.py
@@ -170,6 +170,35 @@ def expand(raw: str, macros: list[Macro]) -> tuple[str, dict[str, str]]:
     return "".join(out), token_map
 
 
+def validate(
+    spellings: list[str],
+    value: str,
+    macros: list[Macro],
+    current: Macro | None,
+) -> tuple[list[str], list[str]]:
+    """Check an edited macro. Returns (errors, warnings): errors block the
+    save (empty trigger/value, spelling that normalizes to nothing), warnings
+    only need confirmation (spelling already used by another macro — the
+    first one would silently win at match time)."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not any(normalize(s) for s in spellings):
+        errors.append("Au moins une orthographe (non vide) est requise.")
+    if not value:
+        errors.append("La valeur est vide.")
+    for s in spellings:
+        if s.strip() and not normalize(s):
+            errors.append(f"« {s} » ne contient aucun mot reconnaissable.")
+    own = {normalize(s) for s in spellings if normalize(s)}
+    for m in macros:
+        if current is not None and m.id == current.id:
+            continue
+        for s in m.spellings:
+            if normalize(s) in own:
+                warnings.append(f"« {s} » est déjà utilisée par la macro « {m.id} ».")
+    return errors, warnings
+
+
 def restore(text: str, token_map: dict[str, str], *, fallback: str | None = None) -> str:
     """Swap tokens back for their verbatim values.
 

--- a/src/dicton/macros_ui.py
+++ b/src/dicton/macros_ui.py
@@ -1,0 +1,320 @@
+"""`dicton macros` — standalone Qt editor for macros.json.
+
+Decoupled from the daemon: the two processes only meet through macros.json
+(the daemon re-reads it on every dictation via an mtime cache), so there is
+no IPC, no file-watcher, no restart.
+
+The 🎤 button records a short take and stores the *raw* Whisper
+transcription as a spelling — exactly what the daemon will see at match
+time. Qt imports stay inside ``run_window`` so importing this module for
+its logic (tests, CLI startup) never loads Qt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import uuid
+
+import httpx
+import numpy as np
+import sounddevice as sd
+
+from . import macros as macros_mod
+from . import stt
+from .config import Config
+from .macros import Macro, normalize
+
+log = logging.getLogger("dicton")
+
+
+# ---- pure CRUD helpers (no Qt) ----
+
+
+def new_macro_id(spelling: str, existing: set[str]) -> str:
+    """Stable id from the first spelling (slug), unique among ``existing``."""
+    base = normalize(spelling).replace(" ", "-") or uuid.uuid4().hex[:8]
+    candidate, n = base, 2
+    while candidate in existing:
+        candidate = f"{base}-{n}"
+        n += 1
+    return candidate
+
+
+def upsert(macros: list[Macro], macro: Macro) -> list[Macro]:
+    """Replace the macro with the same id, or append."""
+    out = [macro if m.id == macro.id else m for m in macros]
+    if macro not in out:
+        out.append(macro)
+    return out
+
+
+def remove(macros: list[Macro], macro_id: str) -> list[Macro]:
+    return [m for m in macros if m.id != macro_id]
+
+
+# ---- spelling capture (record → raw Whisper transcription) ----
+
+
+class Recorder:
+    """Short mono capture for a spoken trigger; returns WAV bytes on stop."""
+
+    def __init__(self, sample_rate: int, device: int | None) -> None:
+        self._sample_rate = sample_rate
+        self._frames: list[np.ndarray] = []
+        self._stream = sd.InputStream(
+            samplerate=sample_rate,
+            channels=1,
+            dtype="int16",
+            callback=self._on_audio,
+            device=device,
+        )
+        self._stream.start()
+
+    def _on_audio(self, indata: np.ndarray, frames, time_info, status) -> None:  # type: ignore[no-untyped-def]
+        self._frames.append(indata[:, 0].copy())
+
+    def stop(self) -> bytes:
+        self._stream.stop()
+        self._stream.close()
+        pcm = np.concatenate(self._frames) if self._frames else np.zeros(0, dtype=np.int16)
+        return stt.pcm16_to_wav(pcm, self._sample_rate)
+
+
+def transcribe_spelling(cfg: Config, wav: bytes) -> str:
+    """Blocking STT call returning the raw transcription (no hallucination
+    filter, no cleanup) — the spelling must be what Whisper actually emits."""
+
+    async def _go() -> str:
+        async with httpx.AsyncClient(http2=True) as client:
+            transcript = await stt.transcribe(
+                client,
+                wav,
+                api_key=cfg.groq_api_key,
+                model=cfg.stt_model,
+                language=cfg.language,
+            )
+            return transcript.raw_text
+
+    return asyncio.run(_go())
+
+
+# ---- Qt window ----
+
+
+def run_window(cfg: Config) -> int:
+    from PySide6 import QtCore, QtWidgets
+
+    class MacrosWindow(QtWidgets.QMainWindow):
+        _spelling_ready = QtCore.Signal(object, str)
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.setWindowTitle("dicton — Macros")
+            self.resize(640, 480)
+            self._macros = list(macros_mod.load())
+            self._current: Macro | None = None
+            self._recorder: Recorder | None = None
+            self._rec_button: QtWidgets.QPushButton | None = None
+            self._spelling_ready.connect(self._fill_spelling)
+            self._build()
+            self._refresh_list()
+
+        # -- layout --
+
+        def _build(self) -> None:
+            root = QtWidgets.QWidget()
+            layout = QtWidgets.QVBoxLayout(root)
+
+            top = QtWidgets.QHBoxLayout()
+            top.addWidget(QtWidgets.QLabel("<b>Macros</b>"))
+            top.addStretch(1)
+            new_btn = QtWidgets.QPushButton("+ Nouvelle")
+            new_btn.clicked.connect(self._new_macro)
+            top.addWidget(new_btn)
+            layout.addLayout(top)
+
+            self._list = QtWidgets.QListWidget()
+            self._list.currentRowChanged.connect(self._select_row)
+            layout.addWidget(self._list, 1)
+
+            editor = QtWidgets.QGroupBox("Édition")
+            form = QtWidgets.QVBoxLayout(editor)
+            form.addWidget(QtWidgets.QLabel("Déclencheur (ce que tu dis) :"))
+            self._spellings_box = QtWidgets.QVBoxLayout()
+            form.addLayout(self._spellings_box)
+            add_spelling = QtWidgets.QPushButton("+ ajouter une orthographe")
+            add_spelling.clicked.connect(lambda: self._add_spelling_row(""))
+            form.addWidget(add_spelling)
+            form.addWidget(QtWidgets.QLabel("Valeur (insérée verbatim) :"))
+            self._value = QtWidgets.QPlainTextEdit()
+            form.addWidget(self._value, 1)
+
+            buttons = QtWidgets.QHBoxLayout()
+            buttons.addStretch(1)
+            save_btn = QtWidgets.QPushButton("Enregistrer")
+            save_btn.clicked.connect(self._save_current)
+            delete_btn = QtWidgets.QPushButton("Supprimer")
+            delete_btn.clicked.connect(self._delete_current)
+            buttons.addWidget(save_btn)
+            buttons.addWidget(delete_btn)
+            form.addLayout(buttons)
+            layout.addWidget(editor, 2)
+
+            self.setCentralWidget(root)
+
+        def _add_spelling_row(self, text: str) -> None:
+            row = QtWidgets.QHBoxLayout()
+            edit = QtWidgets.QLineEdit(text)
+            edit.setPlaceholderText("orthographe Whisper du déclencheur")
+            mic = QtWidgets.QPushButton("🎤")
+            mic.setFixedWidth(36)
+            mic.clicked.connect(lambda *, e=edit, b=mic: self._toggle_record(e, b))
+            rm = QtWidgets.QPushButton("✕")
+            rm.setFixedWidth(28)
+            holder = QtWidgets.QWidget()
+            holder.setLayout(row)
+            rm.clicked.connect(lambda *, h=holder: self._remove_spelling_row(h))
+            row.addWidget(edit, 1)
+            row.addWidget(mic)
+            row.addWidget(rm)
+            row.setContentsMargins(0, 0, 0, 0)
+            self._spellings_box.addWidget(holder)
+
+        def _remove_spelling_row(self, holder: QtWidgets.QWidget) -> None:
+            self._spellings_box.removeWidget(holder)
+            holder.deleteLater()
+
+        def _spelling_edits(self) -> list[QtWidgets.QLineEdit]:
+            edits: list[QtWidgets.QLineEdit] = []
+            for i in range(self._spellings_box.count()):
+                holder = self._spellings_box.itemAt(i).widget()
+                if holder is not None:
+                    edits.extend(holder.findChildren(QtWidgets.QLineEdit))
+            return edits
+
+        def _clear_spelling_rows(self) -> None:
+            while self._spellings_box.count():
+                item = self._spellings_box.takeAt(0)
+                w = item.widget()
+                if w is not None:
+                    w.deleteLater()
+
+        # -- list / editor sync --
+
+        def _refresh_list(self, select_id: str | None = None) -> None:
+            self._list.blockSignals(True)
+            self._list.clear()
+            for m in self._macros:
+                preview = m.value.splitlines()[0] if m.value else ""
+                if len(preview) > 40:
+                    preview = preview[:40] + "…"
+                trigger = m.spellings[0] if m.spellings else m.id
+                self._list.addItem(f"{trigger}  →  {preview}")
+            self._list.blockSignals(False)
+            if self._macros:
+                ids = [m.id for m in self._macros]
+                row = ids.index(select_id) if select_id in ids else 0
+                self._list.setCurrentRow(row)
+            else:
+                self._current = None
+                self._clear_spelling_rows()
+                self._add_spelling_row("")
+                self._value.setPlainText("")
+
+        def _select_row(self, row: int) -> None:
+            if not (0 <= row < len(self._macros)):
+                return
+            self._current = self._macros[row]
+            self._clear_spelling_rows()
+            for sp in self._current.spellings or [""]:
+                self._add_spelling_row(sp)
+            self._value.setPlainText(self._current.value)
+
+        # -- actions --
+
+        def _new_macro(self) -> None:
+            self._current = None
+            self._list.blockSignals(True)
+            self._list.setCurrentRow(-1)
+            self._list.blockSignals(False)
+            self._clear_spelling_rows()
+            self._add_spelling_row("")
+            self._value.setPlainText("")
+
+        def _save_current(self) -> None:
+            spellings = [e.text().strip() for e in self._spelling_edits() if e.text().strip()]
+            value = self._value.toPlainText()
+            errors, warnings = macros_mod.validate(spellings, value, self._macros, self._current)
+            if errors:
+                QtWidgets.QMessageBox.warning(self, "Macro invalide", "\n".join(errors))
+                return
+            if warnings:
+                answer = QtWidgets.QMessageBox.question(
+                    self,
+                    "Orthographe en doublon",
+                    "\n".join(warnings) + "\n\nEnregistrer quand même ?",
+                )
+                if answer != QtWidgets.QMessageBox.StandardButton.Yes:
+                    return
+            if self._current is None:
+                macro_id = new_macro_id(spellings[0], {m.id for m in self._macros})
+                self._current = Macro(id=macro_id, spellings=spellings, value=value)
+            else:
+                self._current.spellings = spellings
+                self._current.value = value
+            self._macros = upsert(self._macros, self._current)
+            macros_mod.save(self._macros)
+            self._refresh_list(select_id=self._current.id)
+
+        def _delete_current(self) -> None:
+            if self._current is None:
+                return
+            self._macros = remove(self._macros, self._current.id)
+            macros_mod.save(self._macros)
+            self._current = None
+            self._refresh_list()
+
+        # -- mic capture --
+
+        def _toggle_record(self, edit: QtWidgets.QLineEdit, button: QtWidgets.QPushButton) -> None:
+            if self._recorder is None:
+                try:
+                    self._recorder = Recorder(cfg.sample_rate, cfg.input_device)
+                except Exception as exc:  # noqa: BLE001 — surface any device error
+                    QtWidgets.QMessageBox.warning(self, "Micro", f"Capture impossible : {exc}")
+                    return
+                self._rec_button = button
+                button.setText("⏹")
+                return
+            if button is not self._rec_button:
+                return  # another row's recording is in progress
+            wav = self._recorder.stop()
+            self._recorder = None
+            button.setText("🎤")
+            button.setEnabled(False)
+
+            def work() -> None:
+                try:
+                    text = transcribe_spelling(cfg, wav)
+                except Exception as exc:  # noqa: BLE001 — show the failure, keep the window alive
+                    log.warning("spelling transcription failed: %s", exc)
+                    text = ""
+                self._spelling_ready.emit(edit, text)
+
+            threading.Thread(target=work, daemon=True).start()
+
+        def _fill_spelling(self, edit: object, text: str) -> None:
+            for known in self._spelling_edits():
+                if known is edit:
+                    known.setText(text)
+                    break
+            if self._rec_button is not None:
+                self._rec_button.setEnabled(True)
+                self._rec_button = None
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = MacrosWindow()
+    window.show()
+    return app.exec()

--- a/src/dicton/pipeline.py
+++ b/src/dicton/pipeline.py
@@ -22,7 +22,7 @@ import sounddevice as sd
 from pynput import keyboard
 
 from . import cleanup as cleanup_mod
-from . import stats, stt
+from . import macros, stats, stt
 from .async_lifecycle import AsyncLoopRunner
 from .chunker import Chunker, ChunkParams
 from .config import Config
@@ -326,12 +326,16 @@ class Pipeline:
             client = self._runner.client
             if client is None:
                 raise RuntimeError("async client is not started")
+            # Macro values are byte-exact and must never reach the cleanup
+            # LLM: swap matches for opaque tokens, clean, swap back.
+            tokenized, macro_tokens = macros.expand(joined, macros.load())
             cleaned = await cleanup_mod.cleanup(
                 client,
-                joined,
+                tokenized,
                 api_key=self.cfg.groq_api_key,
                 model=self.cfg.cleanup_model,
             )
+            cleaned = macros.restore(cleaned, macro_tokens, fallback=tokenized)
             cleanup_ms = int((time.monotonic() - t_cl_start) * 1000)
 
             if self.viz is not None:

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 
 import httpx
 import pytest
@@ -133,7 +134,8 @@ def test_save_load_round_trip(macros_file) -> None:
     loaded = macros.load()
     assert loaded == [CRQPT, SIGNATURE]
     assert loaded[1].value == "Cordialement,\nAsi0\n— alysis"
-    assert (os.stat(macros_file).st_mode & 0o777) == 0o600
+    if sys.platform != "win32":  # POSIX mode bits are meaningless on Windows
+        assert (os.stat(macros_file).st_mode & 0o777) == 0o600
 
 
 def test_load_uses_mtime_cache(macros_file) -> None:

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -1,0 +1,213 @@
+"""Macro engine: normalization, matching, expand/restore, storage, cleanup survival."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+import pytest
+import respx
+
+from dicton import macros
+from dicton.cleanup import cleanup
+from dicton.config import CLEANUP_MODELS
+from dicton.macros import Macro, expand, normalize, restore
+from dicton.stt import GROQ_BASE
+
+CRQPT = Macro(
+    id="crqpt-url", spellings=["crqpt url", "crypte url", "CRQPT URL"], value="https://crqpt.com"
+)
+SIGNATURE = Macro(id="signature", spellings=["ma signature"], value="Cordialement,\nAsi0\n— alysis")
+
+
+# ---- normalize ----
+
+
+def test_normalize_case_accents_punctuation() -> None:
+    assert normalize("CRQPT, URL !") == "crqpt url"
+    assert normalize("  Crypté   URL  ") == "crypte url"
+    assert normalize("l'URL") == "l url"
+    assert normalize("ma-signature…") == "ma signature"
+
+
+def test_normalize_empty_and_punctuation_only() -> None:
+    assert normalize("") == ""
+    assert normalize("…, !") == ""
+
+
+# ---- expand: matching rules ----
+
+
+def test_any_spelling_matches() -> None:
+    for spoken in ["crqpt url", "crypte url", "CRQPT URL", "Crypté URL"]:
+        tokenized, tok = expand(f"envoie le {spoken} au client", [CRQPT])
+        assert len(tok) == 1, spoken
+        assert restore(tokenized, tok) == "envoie le https://crqpt.com au client"
+    # Punctuation glued to the trigger stays outside the token, in the
+    # surrounding text (the cleanup pass owns it).
+    tokenized, tok = expand("envoie le crqpt url. au client", [CRQPT])
+    assert restore(tokenized, tok) == "envoie le https://crqpt.com. au client"
+
+
+def test_word_boundaries_no_match_inside_word() -> None:
+    url = Macro(id="u", spellings=["url"], value="X")
+    tokenized, tok = expand("regarde urlencode et configurl", [url])
+    assert tok == {}
+    assert tokenized == "regarde urlencode et configurl"
+
+
+def test_all_occurrences_replaced() -> None:
+    raw = "crqpt url puis encore crqpt url"
+    tokenized, tok = expand(raw, [CRQPT])
+    assert len(tok) == 2
+    assert restore(tokenized, tok) == "https://crqpt.com puis encore https://crqpt.com"
+
+
+def test_longest_spelling_wins_on_overlap() -> None:
+    short = Macro(id="s", spellings=["crqpt"], value="SHORT")
+    tokenized, tok = expand("le crqpt url ici", [short, CRQPT])
+    assert restore(tokenized, tok) == "le https://crqpt.com ici"
+
+
+def test_dictation_is_only_the_trigger() -> None:
+    tokenized, tok = expand("ma signature", [SIGNATURE])
+    assert restore(tokenized, tok) == "Cordialement,\nAsi0\n— alysis"
+
+
+def test_value_at_sentence_start_is_verbatim() -> None:
+    tokenized, tok = expand("crqpt url est le lien", [CRQPT])
+    assert restore(tokenized, tok) == "https://crqpt.com est le lien"
+
+
+def test_no_macros_passthrough() -> None:
+    assert expand("bonjour monde", []) == ("bonjour monde", {})
+    assert expand("", [CRQPT]) == ("", {})
+
+
+def test_match_across_punctuation_in_dictation() -> None:
+    # Whisper may insert punctuation between trigger words; normalization eats it.
+    tokenized, tok = expand("envoie le crqpt, url maintenant", [CRQPT])
+    assert len(tok) == 1
+    assert restore(tokenized, tok) == "envoie le https://crqpt.com maintenant"
+
+
+# ---- restore: fallback ----
+
+
+def test_restore_fallback_when_token_dropped() -> None:
+    tokenized, tok = expand("envoie le crqpt url au client", [CRQPT])
+    mangled = "Envoie le au client."  # the cleanup model ate the token
+    out = restore(mangled, tok, fallback=tokenized)
+    assert "https://crqpt.com" in out
+    assert out == tokenized.replace(next(iter(tok)), "https://crqpt.com")
+
+
+def test_restore_without_fallback_replaces_what_survives() -> None:
+    tokenized, tok = expand("crqpt url et ma signature", [CRQPT, SIGNATURE])
+    assert restore(tokenized, tok).startswith("https://crqpt.com et Cordialement,")
+
+
+def test_restore_empty_token_map_is_identity() -> None:
+    assert restore("texte propre", {}) == "texte propre"
+
+
+# ---- storage ----
+
+
+@pytest.fixture
+def macros_file(tmp_path, monkeypatch):
+    path = tmp_path / "macros.json"
+    monkeypatch.setattr(macros, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(macros, "MACROS_PATH", path)
+    monkeypatch.setattr(macros, "_cache", None)
+    return path
+
+
+def test_load_missing_file_returns_empty(macros_file) -> None:
+    assert macros.load() == []
+
+
+def test_save_load_round_trip(macros_file) -> None:
+    macros.save([CRQPT, SIGNATURE])
+    loaded = macros.load()
+    assert loaded == [CRQPT, SIGNATURE]
+    assert loaded[1].value == "Cordialement,\nAsi0\n— alysis"
+    assert (os.stat(macros_file).st_mode & 0o777) == 0o600
+
+
+def test_load_uses_mtime_cache(macros_file) -> None:
+    macros.save([CRQPT])
+    first = macros.load()
+    assert macros.load() is first  # same mtime → cached object
+    # Hand-edit the file with a strictly newer mtime → re-read.
+    macros_file.write_text(json.dumps([{"id": "x", "spellings": ["x"], "value": "y"}]))
+    st = os.stat(macros_file)
+    os.utime(macros_file, (st.st_atime, st.st_mtime + 1))
+    assert [m.id for m in macros.load()] == ["x"]
+
+
+def test_load_corrupt_file_disables_macros(macros_file) -> None:
+    macros_file.write_text("{not json")
+    assert macros.load() == []
+    macros_file.write_text(json.dumps([{"id": "a"}]))  # missing keys
+    assert macros.load() == []
+
+
+# ---- cleanup survival (mocked) ----
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_token_survives_cleanup_round_trip() -> None:
+    tokenized, tok = expand("envoie le crqpt url au client", [CRQPT])
+    token = next(iter(tok))
+    respx.post(f"{GROQ_BASE}/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": f"Envoie le {token} au client."}}]},
+        )
+    )
+    async with httpx.AsyncClient(http2=False) as c:
+        cleaned = await cleanup(c, tokenized, api_key="sk-test", model="m")
+    assert restore(cleaned, tok, fallback=tokenized) == "Envoie le https://crqpt.com au client."
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_cleanup_drops_token_falls_back_to_tokenized() -> None:
+    tokenized, tok = expand("envoie le crqpt url au client", [CRQPT])
+    respx.post(f"{GROQ_BASE}/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "Envoie le lien au client."}}]},
+        )
+    )
+    async with httpx.AsyncClient(http2=False) as c:
+        cleaned = await cleanup(c, tokenized, api_key="sk-test", model="m")
+    out = restore(cleaned, tok, fallback=tokenized)
+    assert "https://crqpt.com" in out  # macro fired despite the dropped token
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_cleanup_http_error_keeps_tokenized_input() -> None:
+    tokenized, tok = expand("crqpt url", [CRQPT])
+    respx.post(f"{GROQ_BASE}/chat/completions").mock(return_value=httpx.Response(500))
+    async with httpx.AsyncClient(http2=False) as c:
+        cleaned = await cleanup(c, tokenized, api_key="sk-test", model="m")
+    assert restore(cleaned, tok, fallback=tokenized) == "https://crqpt.com"
+
+
+# ---- token survival against the real models (empirical validation) ----
+# The placeholder scheme rests on cleanup models preserving the token chars.
+# Run with a real key to validate: GROQ_API_KEY=… pytest -k real_models
+@pytest.mark.skipif(not os.environ.get("GROQ_API_KEY"), reason="needs GROQ_API_KEY")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", CLEANUP_MODELS)
+async def test_token_survives_real_models(model: str) -> None:
+    tokenized, tok = expand("envoie le crqpt url au client demain matin", [CRQPT])
+    token = next(iter(tok))
+    async with httpx.AsyncClient(http2=True) as c:
+        cleaned = await cleanup(c, tokenized, api_key=os.environ["GROQ_API_KEY"], model=model)
+    assert token in cleaned, f"{model} dropped the macro token: {cleaned!r}"

--- a/tests/test_macros_ui.py
+++ b/tests/test_macros_ui.py
@@ -1,0 +1,138 @@
+"""Macros editor logic — CRUD helpers, validation, spelling capture wiring.
+
+The Qt window itself is not instantiated here; everything it delegates to
+(id generation, upsert/remove, validate, record → raw STT) is plain Python.
+"""
+
+from __future__ import annotations
+
+import httpx
+import numpy as np
+import pytest
+import respx
+
+from dicton import macros_ui
+from dicton.config import Config
+from dicton.macros import Macro, validate
+from dicton.macros_ui import Recorder, new_macro_id, remove, transcribe_spelling, upsert
+from dicton.stt import GROQ_BASE
+
+CRQPT = Macro(id="crqpt-url", spellings=["crqpt url"], value="https://crqpt.com")
+SIGNATURE = Macro(id="signature", spellings=["ma signature"], value="Cordialement")
+
+
+# ---- id generation ----
+
+
+def test_new_macro_id_slugs_the_spelling() -> None:
+    assert new_macro_id("CRQPT, URL !", set()) == "crqpt-url"
+
+
+def test_new_macro_id_uniquifies() -> None:
+    assert new_macro_id("crqpt url", {"crqpt-url"}) == "crqpt-url-2"
+    assert new_macro_id("crqpt url", {"crqpt-url", "crqpt-url-2"}) == "crqpt-url-3"
+
+
+def test_new_macro_id_falls_back_to_uuid_on_empty() -> None:
+    generated = new_macro_id("…!", set())
+    assert len(generated) == 8
+
+
+# ---- upsert / remove ----
+
+
+def test_upsert_appends_new_macro() -> None:
+    assert upsert([CRQPT], SIGNATURE) == [CRQPT, SIGNATURE]
+
+
+def test_upsert_replaces_same_id() -> None:
+    edited = Macro(id="crqpt-url", spellings=["crqpt url", "crypte url"], value="https://crqpt.com")
+    out = upsert([CRQPT, SIGNATURE], edited)
+    assert out == [edited, SIGNATURE]
+
+
+def test_remove_by_id() -> None:
+    assert remove([CRQPT, SIGNATURE], "crqpt-url") == [SIGNATURE]
+    assert remove([CRQPT], "unknown") == [CRQPT]
+
+
+# ---- validation ----
+
+
+def test_validate_requires_spelling_and_value() -> None:
+    errors, _ = validate([], "", [], None)
+    assert len(errors) == 2
+    errors, _ = validate(["  "], "x", [], None)
+    assert len(errors) == 1
+
+
+def test_validate_rejects_unmatchable_spelling() -> None:
+    errors, _ = validate(["crqpt url", "…!"], "v", [], None)
+    assert any("…!" in e for e in errors)
+
+
+def test_validate_warns_on_duplicate_spelling_across_macros() -> None:
+    errors, warnings = validate(["CRQPT URL."], "v", [CRQPT, SIGNATURE], None)
+    assert errors == []
+    assert len(warnings) == 1
+    assert "crqpt-url" in warnings[0]
+
+
+def test_validate_ignores_own_macro_for_duplicates() -> None:
+    errors, warnings = validate(["crqpt url"], "v", [CRQPT], CRQPT)
+    assert errors == []
+    assert warnings == []
+
+
+# ---- spelling capture ----
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_transcribe_spelling_returns_raw_text() -> None:
+    respx.post(f"{GROQ_BASE}/audio/transcriptions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "text": "crypte url",
+                "segments": [
+                    {
+                        "text": " crypte url",
+                        # Raw means raw: a segment the hallucination filter
+                        # would drop must still come through as a spelling.
+                        "no_speech_prob": 0.95,
+                        "avg_logprob": -1.2,
+                        "compression_ratio": 0.8,
+                    }
+                ],
+            },
+        )
+    )
+    cfg = Config(groq_api_key="sk-test")
+    import asyncio
+
+    text = await asyncio.to_thread(transcribe_spelling, cfg, b"WAVE")
+    assert text == "crypte url"
+
+
+def test_recorder_collects_frames_into_wav(monkeypatch) -> None:
+    class FakeStream:
+        def __init__(self, *, callback, **kwargs):
+            self.callback = callback
+
+        def start(self):
+            frame = np.ones((160, 1), dtype=np.int16)
+            self.callback(frame, 160, None, None)
+            self.callback(frame * 2, 160, None, None)
+
+        def stop(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(macros_ui.sd, "InputStream", FakeStream)
+    rec = Recorder(16000, None)
+    wav = rec.stop()
+    assert wav[:4] == b"RIFF"
+    assert len(wav) > 44 + 2 * 320 - 1  # header + 320 samples of int16


### PR DESCRIPTION
Implements [docs/features/macros.md](https://github.com/Asi0Flammeus/dicton/blob/feat/macros/docs/features/macros.md) — the full tracer-bullet plan, all three phases.

## What

A **Macro** maps spoken trigger *spellings* (known Whisper transcriptions) to a **byte-exact value** — from a URL (« crqpt url » → `https://crqpt.com`) to a multi-paragraph signature. Detection is inline on every dictation, no sentinel word.

## How

- **`src/dicton/macros.py`** — engine: normalized word-boundary matching (casefold, no accents/punctuation), multiple spellings per macro, longest spelling wins, all occurrences replaced. Storage in `~/.config/dicton/macros.json` (0600), re-read by the daemon via mtime cache — no IPC, no restart.
- **LLM safety** — the value never reaches the cleanup model: `expand()` swaps matches for opaque tokens before cleanup, `restore()` swaps them back verbatim after, with a pre-cleanup fallback if a token is dropped (reliability > polish).
- **`src/dicton/macros_ui.py` + `dicton macros`** — standalone Qt editor (list/create/edit/delete), spellings typed or 🎤-recorded (short capture + `stt.transcribe`, raw transcription stored), multi-line value. Validation: empty trigger/value blocks, duplicate spelling across macros asks confirmation.
- **`pipeline.py`** — 3-line wiring around the cleanup call.

## Empirical token validation (the spec's key risk)

Tested candidate token formats against all 4 `CLEANUP_MODELS` with the real cleanup prompt (3 takes each):

| Format | Result |
|---|---|
| `⟦M0⟧`, `[[M0]]`, `{{M0}}`, `@@M0@@`, `__M0__` | decoration stripped by ≥1 Llama model |
| U+E000 (private use, the doc's initial suggestion) | deleted by 3/4 models |
| **bare alphanumeric `QZM0XQZ`** | **preserved 12/12 by all 4 models** ✅ |

The retained token is a bare opaque alphanumeric run. `test_token_survives_real_models` (gated on `GROQ_API_KEY`) replays this validation against the live API — it passed on all 4 models.

## Tests

- 36 new tests (engine matching rules, storage/mtime cache, cleanup round-trip + fallback via respx, CRUD/validate/STT-wiring for the editor).
- Full suite: **100 passed**, `./scripts/check.sh all` green.
- Editor window smoke-tested offscreen (`QT_QPA_PLATFORM=offscreen`).

## Out of scope (v1, per spec)

Dynamic content, per-app macros, nested macros, regex, sentinel word (kept as the cheap fallback if bare inline proves noisy).